### PR TITLE
rename repo links to Axway org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,7 +72,7 @@ privacy_policy = "https://www.axway.com/en/privacy-statement"
 version_menu = "Releases"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/alexearnshaw/axway-open-docs"
+github_repo = "https://github.com/Axway/axway-open-docs"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 # github_project_repo = "https://github.com/google/docsy"
 
@@ -102,8 +102,8 @@ footer_about_disable = true
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/alexearnshaw/axway-open-docs/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/alexearnshaw/axway-open-docs/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -9,7 +9,7 @@ linkTitle = "TechOS"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/alexearnshaw/axway-open-docs">
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/Axway/axway-open-docs">
 		Repository <i class="fab fa-github ml-2 "></i>
 	</a>
 	<p class="lead mt-5">You can now contribute to the documentation directly!</p>

--- a/content/en/docs/contribution_guidelines/setup_work_locally.md
+++ b/content/en/docs/contribution_guidelines/setup_work_locally.md
@@ -19,7 +19,7 @@ If you are a maintainer of this documentation site, or a contributor who will be
 Clone the git repo. Don't forget to use `--recurse-submodules` or you won't pull down some of the code you need to generate a working site.
 
 ```
-git clone --recurse-submodules --depth 1 https://github.com/alexearnshaw/axway-open-docs.git
+git clone --recurse-submodules --depth 1 https://github.com/Axway/axway-open-docs.git
 ```
 
 ## Install Hugo

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: github
-  repo: alexearnshaw/axway-open-docs # Path to your GitHub repository
+  repo: Axway/axway-open-docs # Path to your GitHub repository
   fork_workflow: true
 
 publish_mode: editorial_workflow


### PR DESCRIPTION
- Global search and replace all instances of the Github repo with the new repo name under the Axway org in all config and other files

- This involves no changes to content except for any links to the repo that are generated by Hugo/Netlify from the config files