### PR TITLE
IAP-2492: remove or backtick lt, gt, and backslash chars for zoomin

### DIFF
--- a/content/en/docs/apiportal_admin/_index.md
+++ b/content/en/docs/apiportal_admin/_index.md
@@ -1,6 +1,6 @@
 {"title":"Administer API Portal","linkTitle":"Administer API Portal","no_list":"true","date":"2019-07-30","description":""}
 
-AxwayAPI Portal is a self-service developer portal layered on both API Manager and API Gateway.
+Axway API Portal is a self-service developer portal layered on both API Manager and API Gateway.
 
 With API Portal, you can enable both internal or external client application developers to browse, consume, build, and test APIs for use in their applications on their own. You can use several channels, such as FAQs, articles, forums or blogs, to provide more information for the developers and to encourage developer engagement. The look and feel of the web-based API Portal is fully customizable to match your brand and image.
 

--- a/content/en/docs/apiportal_admin/customize_css_styles.md
+++ b/content/en/docs/apiportal_admin/customize_css_styles.md
@@ -27,17 +27,21 @@ When planning changes to CSS files, you can quickly check which file controls th
 {{< alert title="" color="warning">}}It is not recommended to manually edit the `less/themes/axway/variables-custom.less` file. This file contains the attribute values customized in the ThemeMagic editor. For more details, see [Customize with ThemeMagic](themingCustomStyles.htm).{{< /alert >}}
 
 1. Log in to the Joomla! Admin Interface (JAI), and click **Extensions > Templates**.
-1. In the Template sidebar, click **Templates**, and select **Purity III\_Details and Files**.
+1. In the Template sidebar, click **Templates**, and select **Purity III_Details and Files**.
 ![API Portal customizatoin list of available templates through Purity tool](/Images/APIPortal/customation_puritIII_detailsandfiles.png)
 1. On the **Editor** tab, open the following folder:
-1. local/css/themes/<your theme>
+
+    ```
+    local/css/themes/<your theme>
+    ```
+
 1. Select the `template.less` file containing the element, and locate the correct line. In this example, the value for `text-transform` is changed from inherit to uppercase.
 ![An example screenshot on editing a style css.](/Images/APIPortal/cssjoomlasamplecodechange.png)
 1. Select **Save > Close File**, and close the editor.
 1. In Templates sidebar, select **Styles**.
 1. Select **Purity III - Default**, and click **</> LESS to CSS** to compile a new css file.
 ![Joomla Purity III styles template manager to compile changes to API Portal css](/Images/APIPortal/csspuriistylesconfig.png)
-1. Refresh the API Portal home page in the browser to see the changes you have made.\
+1. Refresh the API Portal home page in the browser to see the changes you have made.
 
 ## Add a custom stylesheet
 
@@ -45,12 +49,12 @@ If you rather use a css files to edit the look and feel of your page, add a new 
 
 The custom css file is the last file to be loaded in your site. The custom css file is not compiled from the Less variables, so it is not overridden or lost if you decide compile another css file using the Less variables.
 
-You can also manually edit the Less files in local/less/themes/<your copy of axway theme> folder. After modifications, compile the `.less` files to CSS. For more details, see [Customize CSS styles](customize_css_styles.htm).
+You can also manually edit the Less files in `local/less/themes/<your copy of axway theme>` folder. After modifications, compile the `.less` files to CSS. For more details, see [Customize CSS styles](customize_css_styles.htm).
 
 ### Create or upload a custom stylesheet
 
 1.  Log in to Joomla! Administrator Interface (JAI), and click **Extensions > Templates**.
-2.  In the Templates sidebar, click **Templates**, and select the style **Purity III\_Details and Files**.
+2.  In the Templates sidebar, click **Templates**, and select the style **Purity III_Details and Files**.
 3.  On the **Editor** tab, select **New file**.
 4.  Select the `css` folder, set **File Type** to `css`, enter a name for you file (such as `custom.css`), and click **Create**. To upload a css file, click **Choose File**, select the css file you want, and click **Upload**.
 
@@ -61,7 +65,7 @@ You can now edit your custom stylesheet in JAI like any css file.
 You can also copy a css file already included in the Purity III - Default style as your custom stylesheet.
 
 1.  In JAI, click **Extensions > Templates**.
-2.  In the Templates sidebar, click **Templates**, and select the style **Purity III\_Details and Files**.
+2.  In the Templates sidebar, click **Templates**, and select the style **Purity III_Details and Files**.
 3.  On the **Editor** tab, open the css folder, select the css file to copy, and click **New file**.
 4.  Select the `css` folder, enter a name for you copy (such as `copied-custom.css`) in **Copied File Name**, and click **Copy File**.
 
@@ -72,7 +76,7 @@ You can now edit the details you want in your copied custom stylesheet.
 If you need the Less functionality in the custom stylesheet as well, create a less file for your custom css file. This less file compiles the Less variables to your custom css file.
 
 1.  In JAI, click **Extensions > Templates**.
-2.  In the Template sidebar, click **Templates**, and select the style **Purity III\_Details and Files**.
+2.  In the Template sidebar, click **Templates**, and select the style **Purity III_Details and Files**.
 3.  On the **Editor** tab, select **New file**.
 4.  Select the `less` folder, set **File Type** to `less`, set **File Name** to `<your css file name>.less`, and click **Create**.
 

--- a/content/en/docs/apiportal_admin/customize_getting_started.md
+++ b/content/en/docs/apiportal_admin/customize_getting_started.md
@@ -1,6 +1,4 @@
-{"title":"Customize API Portal look and feel","linkTitle":"Customize API Portal look and feel","weight":"1","date":"2019-07-30","description":""}
-
-This section provides the basic information you need to get started with customizing your branded API Portal.
+{"title":"Customize API Portal look and feel","linkTitle":"Customize API Portal look and feel","weight":"1","date":"2019-07-30","description":"Get started with customizing your branded API Portal."}
 
 For internally-facing API deployments, you can deploy API Portal "as is" using the out-of-the-box Axway branding. This type of deployment requires no customization.
 
@@ -10,153 +8,143 @@ For external-facing API deployments, you may want to customize API Portal to pr
 
 Customization can be performed at three levels:
 
--   **Customization through configuration**: Use the Joomla! Admin Interface (JAI) (https://<API Portal host>/administrator) to change CSS stylesheets, templates, and layouts. These types of customizations are can be upgraded and retained when you move to new version. The customization does not modify the API Portal source code and is supported by Axway.
--   **Customization through code**: API Portal is developed using the PHP scripting language and the source code is provided. This is how Joomla! applications are deployed. You can modify the PHP source code to customize API Portal, such as to change the functionality of pages and to extend by adding new pages.
+- **Customization through configuration**: Use the Joomla! Admin Interface (JAI) (https://<API Portal host>/administrator) to change CSS stylesheets, templates, and layouts. These types of customizations are can be upgraded and retained when you move to new version. The customization does not modify the API Portal source code and is supported by Axway.
+- **Customization through code**: API Portal is developed using the PHP scripting language and the source code is provided. This is how Joomla! applications are deployed. You can modify the PHP source code to customize API Portal, such as to change the functionality of pages and to extend by adding new pages. This type of customization is only recommended for customers with Joomla! or PHP experience that need to deploy a highly tailored developer portal.
 
-    <div class="indentTableNested">
+    {{< alert title="Caution" color="warning" >}}These customizations are lost when you upgrade. The source code is subject to frequent changes without notice; therefore, you must reintegrate customizations into the new API Portal code to avoid restoring a deprecated code along with the customizations.{{< /alert >}}
 
-    -   The customizations are lost when you upgrade. The source code is subject to frequent changes without notice; therefore, you must reintegrate customizations into the new API Portal code to avoid restoring a deprecated code along with the customizations.
-    -   If you submit a case to Axway Support and it is suspected that the customizations may be the root cause of the issue, you must reproduce the issue on a non-customized API Portal.
-    -   This type of customization is only recommended for customers with Joomla!/PHP experience that need to deploy a highly tailored developer portal.\
+- **Customization through the addition of Joomla! plug-ins**: The Joomla! CMS offers thousands of extensions that are available from their website. Axway is only responsible for the support to extensions that are delivered out of the box (EasyBlog and EasyDiscuss).
 
-    </div>
-
--   **Customization through the addition of Joomla! plug-ins**: The Joomla! CMS offers thousands of extensions that are available from their website. Axway is only responsible for the support to extensions that are delivered out of the box (EasyBlog and EasyDiscuss).
--   {{< alert title="" color="warning" >}} If you submit a case to Axway Support and it is suspected that unsupported third-party extensions may be the root cause of the issue, you must reproduce the issue on a non-customized API Portal.{{< /alert >}}
+{{< alert title="Caution" color="warning" >}} If you submit a case to Axway Support and it is suspected that unsupported third-party extensions may be the root cause of the issue, you must reproduce the issue on a non-customized API Portal.{{< /alert >}}
 
 ## Prerequisites
 
 To get started with customization, you need the following:
 
--   API Portal installed and configured. For more details, see the [API Portal Installation and Upgrade Guide](/bundle/APIPortal_77_InstallationGuide_allOS_en_HTML5) .
--   An API Portal user account. When you log in, the default API Portal web page is displayed, so you can check how the changes look to your end users.
--   Basic understanding of [Joomla! ThemeMagic](themingCustomStyles.htm). This feature enables to change CSS stylesheets, templates, and layouts. For more advanced modifications, you can modify the PHP source code to customize API Portal, such as to change the functionality of pages and to extend by adding new pages.
+- API Portal installed and configured. For more details, see the [API Portal Installation and Upgrade Guide](/bundle/APIPortal_77_InstallationGuide_allOS_en_HTML5) .
+- An API Portal user account. When you log in, the default API Portal web page is displayed, so you can check how the changes look to your end users.
+- Basic understanding of Joomla! ThemeMagic. This feature enables you to change CSS stylesheets, templates, and layouts. For more advanced modifications, you can modify the PHP source code to customize API Portal, such as to change the functionality of pages and to extend by adding new pages.
 
-# Customize with ThemeMagic
+## Customize with ThemeMagic
+
 API Portal uses the Joomla! framework to extend the ThemeMagic feature. ThemeMagic is part of the Purity III template that is based on the T3 template framework.
 
 With ThemeMagic, you have an administrative interface for creating or modifying themes, such as colors and fonts. Use the live preview to follow how your theme configuration looks before saving the changes. Themes are built using theming variables based on the [Less](http://lesscss.org/) language.
 
-## Open ThemeMagic
+### Open ThemeMagic
 
-1.  Log in to the Joomla! Administrator Interface (JAI), and click **Extensions > Templates**.
-2.  In Templates sidebar, select **Styles**, then select the style **Purity III - Default**.
-3.  ![Joomla user interface with Purity III selecting the styles](/Images/APIPortal/JoomlaThemeMagicStyles.png)
+1. Log in to the Joomla! Administrator Interface (JAI), and click **Extensions > Templates**.
+2. In Templates sidebar, select **Styles**, then select the style **Purity III - Default**.
+    ![Joomla user interface with Purity III selecting the styles](/Images/APIPortal/JoomlaThemeMagicStyles.png)
+3. Select **ThemeMagic**. ThemeMagic opens your portal home page with theme variables are displayed on the left.
+    ![Joomla User Interface with Purity III theme magic](/Images/APIPortal/joomlathememagic.png)
+4. In the ThemeMagic window, sign in to API Portal. You are now ready to start customizing your portal.
+    ![Screenshot on ThemeMagic](/Images/APIPortal/JoomlaThemeMagiconAPIPortal.png)
 
-4.  Select **ThemeMagic**. ThemeMagic opens your portal home page with theme variables are displayed on the left.
-5.  ![Joomla User Interface with Purity III theme magic](/Images/APIPortal/joomlathememagic.png)
-
-6.  In the ThemeMagic window, sign in to API Portal. You are now ready to start customizing your portal.
-7.  ![Screenshot on ThemeMagic](/Images/APIPortal/JoomlaThemeMagiconAPIPortal.png)
-
-## Create a new theme
+### Create a new theme
 
 API Portal includes one theme named **Axway**. It is recommended to create any additional themes from a copy of the Axway theme to ensure they work properly.
 
-1.  Open the ThemeMagic tool, and ensure the Theme is the default **Axway** theme.
-2.  Click the drop-down menu next to the Preview button, and select **Save As**:
-3.  ![API Portal customize color screen](/Images/APIPortal/portal_customize.png)
+1. Open the ThemeMagic tool, and ensure the Theme is the default **Axway** theme.
+2. Click the drop-down menu next to the Preview button, and select **Save As**:
+    ![API Portal customize color screen](/Images/APIPortal/portal_customize.png)
+3. Enter a name for your theme, click **Accept**, and wait until the new theme is ready. A new folder is created for your new theme in local/less/themes/.
+    ![API Portal ThemeMagic screen to enter the theme name](/Images/APIPortal/thememagic.png)
+4. Ensure the **Theme** selected is your new theme, and change the theming variables on the left as needed to customize your theme.
+5. To check how your changes look on the page, click **Preview**.
+6. When you are happy with your theme, click the drop-down menu, and select **Save**.
 
-4.  Enter a name for your theme, click **Accept**, and wait until the new theme is ready. A new folder is created for your new theme in local/less/themes/.
-5.  ![API Portal ThemeMagic screen to enter the theme name](/Images/APIPortal/thememagic.png)
-
-6.  Ensure the **Theme** selected is your new theme, and change the theming variables on the left as needed to customize your theme.
-7.  To check how your changes look on the page, click **Preview**.
-8.  When you are happy with your theme, click the drop-down menu, and select **Save**.
-
-### Theming variables
+#### Theming variables
 
 Theming variables are grouped into different levels:
 
--   **Key Colors**: These variables control the base colors for all styles. The default key colors are sea blue and gray.
--   **Basic Colors**: These variables control the colors of the major UI elements, such as buttons and menus. The default values for the basic colors are based on the key colors, but you can overridden these to control the styles of individual UI elements.
--   **Global Fonts** and **Headings**: These variables control the typefaces and sizes of the main text elements
+- **Key Colors**: These variables control the base colors for all styles. The default key colors are sea blue and gray.
+- **Basic Colors**: These variables control the colors of the major UI elements, such as buttons and menus. The default values for the basic colors are based on the key colors, but you can overridden these to control the styles of individual UI elements.
+- **Global Fonts** and **Headings**: These variables control the typefaces and sizes of the main text elements
 
 In addition, there are some other variables for fine-grain customization of the UI elements, if needed. Most of these variables are based on Basic Color variables.
 
-{{< alert title="" color="primary" >}}Variable names begin with the "@" character in Less language. In addition to variable values, you can also use Less expressions and functions to set the value of a theme variable.{{< /alert >}}
+{{< alert title="Note" color="primary" >}}Variable names begin with the "@" character in Less language. In addition to variable values, you can also use Less expressions and functions to set the value of a theme variable.{{< /alert >}}
 
-Use the new theme
------------------
+### Use the new theme
 
-1.  In JAI, click **Extensions > Templates**.
-2.  In the Templates sidebar, select **Styles**, then select the style **Purity III - Default**.
-3.  Select the **Theme** page, and select your new theme from the **Theme** drop-down menu:
-4.  ![API Portal sample screen on how to save a new theme in templates](/Images/APIPortal/portal_templates.png)
+1. In JAI, click **Extensions > Templates**.
+2. In the Templates sidebar, select **Styles**, then select the style **Purity III - Default**.
+3. Select the **Theme** page, and select your new theme from the **Theme** drop-down menu:
+    ![API Portal sample screen on how to save a new theme in templates](/Images/APIPortal/portal_templates.png)
+4. Click **Save**, then click **</> Less to CSS**. This is the preferred option as it will only compile the theme you want to use.
 
-5.  Click **Save**, then click **</> Less to CSS**. This is the preferred option as it will only compile the theme you want to use.
-
-Configuration files
--------------------
+### Configuration files
 
 API Portal includes files added to the Purity III template's folders and files that replace those belonging to the Purity III template. All paths are relative to the Purity III template's folder.
 
--   Before updating the Purity III template or T3 framework, back up the Purity III files API Portal replaces. After the update, restore or merge the backed up files.
--   Before updating the API Portal plugin, if you have customized the Axway theme or any of the mentioned configuration files, back up the files to avoid losing your customizations. After the update, you may have to merge the backed up files.
+- Before updating the Purity III template or T3 framework, back up the Purity III files API Portal replaces. After the update, restore or merge the backed up files.
+- Before updating the API Portal plugin, if you have customized the Axway theme or any of the mentioned configuration files, back up the files to avoid losing your customizations. After the update, you may have to merge the backed up files.
 
 #### Added files
 
 The following list details the added files:
 
--   `less/themes/axway/template.less` – Styles for the theme.
--   `less/themes/axway/variables.less` – Theme values customized in a file editor.
--   `less/themes/axway/variables-custom.less` – Theme values customized in the ThemeMagic. Do not edit this file manually.
+- `less/themes/axway/template.less` – Styles for the theme.
+- `less/themes/axway/variables.less` – Theme values customized in a file editor.
+- `less/themes/axway/variables-custom.less` – Theme values customized in the ThemeMagic. Do not edit this file manually.
 
 #### Replaced Purity III files
 
 The following list summarizes the replaced Purity III files:
 
--   `thememagic.xml` – Configuration for the ThemeMagic GUI.
--   `language/en-GB/en-GB.tpl_purity_iii.ini` – Language strings displayed in the ThemeMagic GUI. In order to be utilized by ThemeMagic, this file must be copied to Joomla!'s main language folder, `language/en-GB/en-GB.tpl_purity_iii.ini` when the API Portal plugin is installed.
--   `less/variables.less` – Global variables for the Purity III template. Default values for theming variables must be defined in this file.
+- `thememagic.xml` – Configuration for the ThemeMagic GUI.
+- `language/en-GB/en-GB.tpl_purity_iii.ini` – Language strings displayed in the ThemeMagic GUI. In order to be utilized by ThemeMagic, this file must be copied to Joomla!'s main language folder, `language/en-GB/en-GB.tpl_purity_iii.ini` when the API Portal plugin is installed.
+- `less/variables.less` – Global variables for the Purity III template. Default values for theming variables must be defined in this file.
 
-# Customize your logo
+## Customize your logo
+
 This section describes how to change the API Portal site logo using the Joomla! Media Manager.
 
-## Upload your image file
+### Upload your image file
 
 1. In Joomla! Administrator Interface (JAI), click **Content > Media**.
-2. Under **Media Folders**, click **com\_apiportal > menu**.
+2. Under **Media Folders**, click **com_apiportal > menu**.
 3. Upload the image file you want to use, and select **Save**.
 
-## Link the logo to your home page
+### Link the logo to your home page
 
 To configure the main menu to link your logo to the home page:
 
 1. In JAI, click **Menus > Main Menu**. A list of menu items is displayed.
 2. In the list of menu items, click **Home**. This is the first item where the logo is attached.
 3. Go to the **Link Type** tab, and in **Link Image**, click **Select**.
-4. In **Folder**, select the folder **com\_apiportal/menu**.
+4. In **Folder**, select the folder **com_apiportal/menu**.
 5. Select your logo from the list of the available image files, and click **Insert**.
 6. Click **Save**.
 7. Refresh the API Portal home page in the browser. Your selected logo is displayed.
 
+## Customize your 404 page
 
-## Customize 404 page
 This section describes how you can customize a `404` page for your API Portal.
 
-<!-- ### Create a template -->
+### Create a template
 
-Follow these steps create a new template for your new `404 `page.
+Follow these steps create a new template for your new `404` page.
 
 1. Log in to the Joomla! Administrator Interface (JAI), and click **Extensions > Templates**.
-2. Select **Templates** in the sidebar, and click the template **Purity\_III Details and Files**.
+2. Select **Templates** in the sidebar, and click the template **Purity_III Details and Files**.
 3. Click **Copy Template**.
 4. Enter a name for the template and click **Copy Template**.
 5. Click **Close**.
 
-<!-- ### Customize the page  -->
+### Customize the page
 
 Customize the message for the page.
 
 1. From the list of templates, click your new template.
 2. On the **Editor** tab, click **error.php** to edit this file.
-3. Customize the line describing the `404 `page.
+3. Customize the line describing the `404` page.
 4. Save and close the template.
 
-<!-- ### Assign the template -->
+### Assign the template
 
-Assign your new template as the default `404 `page in API Portal.
+Assign your new template as the default `404` page in API Portal.
 
 1. Select **Styles** in the sidebar.
 2. On the list of styles, locate the style created for your new template and click **Default**.

--- a/content/en/docs/apiportal_admin/customize_page_content.md
+++ b/content/en/docs/apiportal_admin/customize_page_content.md
@@ -14,8 +14,8 @@ reCaptcha is a free service you can add to the API Portal sign up page to preve
 2.  Give a label for your site (such as `API Portal`) label, enter the API Portal domain (here `localhost.localdomain`) in the **Domains** field, and select **Register**.
 3.  ![reCaptcha screen with register a new site with lable and domains displayed](/Images/APIPortal/reCatchalocalhostlocaldomain.png)
 
-4.  Select the domain, and review how to add the reCaptcha:\
-    \
+4.  Select the domain, and review how to add the reCaptcha:
+    
     ![reCaptcha screen that display how to add reCAPTCHA to the API Portal](/Images/APIPortal/recaptchasitekeysteps.png)
 5.  Log in to the Joomla! Administrator Interface (JAI) (`https://<API Portal_host>/administrator`).
 6.  Select **Extensions > Plugins**.
@@ -87,7 +87,7 @@ To enable this feature follow these steps:
 3.  From the list of module types click **Custom**.
 4.  Enter a title for the message.
 5.  Use the text editor to enter the text for the message.
-6.  Select **Purity\_iii** > **login-message-consent** from the **Position** list.
+6.  Select **Purity_iii** > **login-message-consent** from the **Position** list.
 7.  Click **Save &** **Close**.
 8.  Go to the API Portal Sign In page, refresh the page, and verify that the banner is shown.
 
@@ -167,7 +167,7 @@ You can customize your company's footer by adding more text to it.
 1.  In the JAI, click **Extensions > Modules**.
 2.  Click **New** to create a new module.
 3.  From the list of module types click **Custom**.
-4.  On the right sidebar, select 'Footer\[footer\]' from the **Position list**, and select 'Hide' on the **Show title** option.
+4.  On the right sidebar, select 'Footer[footer]' from the **Position list**, and select 'Hide' on the **Show title** option.
 5.  Use the text editor to enter the text.
 6.  Click **Save**.
 

--- a/content/en/docs/apiportal_admin/localize_language.md
+++ b/content/en/docs/apiportal_admin/localize_language.md
@@ -245,9 +245,9 @@ To enable a language switcher, you need to have template styles for each languag
 
 By default, API Portal uses the Purity III template style. After following this process you will have the following template styles:
 
--   purity\_III - Default - English
--   purity\_III - Default - French
--   purity\_III - Default - All
+-   purity_III - Default - English
+-   purity_III - Default - French
+-   purity_III - Default - All
 
 ### Duplicate the template style for the new language
 

--- a/content/en/docs/apiportal_admin/troubleshooting.md
+++ b/content/en/docs/apiportal_admin/troubleshooting.md
@@ -20,7 +20,7 @@ API response class details missing
 
 The following is an example of missing response class details. An `array[null]` value is displayed instead of details:
 
-![An example of an "array\[null\]" Response Class with missing details](/Images/APIPortal/troubleshooting1.png)
+![An example of an "array[null]" Response Class with missing details](/Images/APIPortal/troubleshooting1.png)
 
 The following is an example of the expected response class details:
 

--- a/content/en/docs/cass_admin/cassandra_config.md
+++ b/content/en/docs/cass_admin/cassandra_config.md
@@ -136,11 +136,11 @@ This section assumes that you have already set up a HA API Gateway environment. 
 
 In Policy Studio, open your API Gateway group configuration.
 
-1.  Select **Server Settings \> Cassandra \> Authentication**, and enter
+1.  Select **Server Settings > Cassandra > Authentication**, and enter
     the cassandra database user name and password.
-2.  Select **Server Settings \> Cassandra \> Hosts**, and add a host for
+2.  Select **Server Settings > Cassandra > Hosts**, and add a host for
     each Cassandra node in the cluster.
-3.  Select **Server Settings \> Cassandra \> Keyspace**, and set the
+3.  Select **Server Settings > Cassandra > Keyspace**, and set the
     **Initial replication factor** option to `3`.
 4.  Deploy the configuration to the group.
 
@@ -171,9 +171,9 @@ the following steps:
 #### Configure the API Gateway Cassandra client connection
 
 1.  In Policy Studio, open your API Gateway group configuration.
-2.  Select **Server Settings \> Cassandra \> Authentication**, and enter
+2.  Select **Server Settings > Cassandra > Authentication**, and enter
     your Cassandra user name and password (both default to `cassandra`).
-3.  Select **Server Settings \> Cassandra \> Hosts**, and add an address
+3.  Select **Server Settings > Cassandra > Hosts**, and add an address
     for each Cassandra node in the cluster (`ipA`, `ipB` and `ipC` in this example).
 
 {{% alert title="Tip" %}}
@@ -183,7 +183,7 @@ You can automate these steps by running the `updateCassandraSettings.py` script 
 #### Configure the API Gateway Cassandra consistency levels
 
 1.  Ensure that the **API Server** KPS collection has been created under
-    **Environment Configuration \> Key Property Stores**. This is
+    **Environment Configuration > Key Property Stores**. This is
     required to configure Cassandra consistency levels, and is created
     automatically if you installed the **Complete** setup type.
 
@@ -194,8 +194,7 @@ You can automate these steps by running the `updateCassandraSettings.py` script 
       - [Deploy OAuth configuration](/csh?context=400&product=prod-api-gateway-77) in the [API Gateway OAuth User Guide](/bundle/APIGateway_77_OAuthUserGuide_allOS_en_HTML5/)
       - [Configure API Manager Cassandra client settings](#configure-api-manager-cassandra-client-settings)
 
-3.  Select **Environment Configuration \> Key Property Stores \> API
-    Server \> Data Sources \> Cassandra Storage**, and click **Edit**.
+3.  Select **Environment Configuration > Key Property Stores > API Server > Data Sources > Cassandra Storage**, and click **Edit**.
 
 4.  In the **Read Consistency Level** and **Write Consistency Level**
     fields, select
@@ -203,16 +202,14 @@ You can automate these steps by running the `updateCassandraSettings.py` script 
     ![](/Images/docbook/images/api_mgmt/api_mgmt_embedded_kps.png)
 
 1.  Repeat this step for each KPS collection using Cassandra (for
-    example, **Key Property Stores \> OAuth**, or **API Portal** for API
+    example, **Key Property Stores > OAuth**, or **API Portal** for API
     Manager). This also applies to any custom KPS collections that you
     have created.
 2.  If you are using OAuth and Cassandra, you must also configure quorum
-    consistency for all OAuth2 stores under **Libraries \> OAuth2
-    Stores**:
-      - **Access Token Stores \> OAuth Access Token Store**
-      - **Authorization Code Stores \> Authz Code Store**
-      - **Client Access Token Stores \> OAuth Client Access Token
-        Store**
+    consistency for all OAuth2 stores under **Libraries > OAuth2 Stores**:
+      - **Access Token Stores > OAuth Access Token Store**
+      - **Authorization Code Stores > Authz Code Store**
+      - **Client Access Token Stores > OAuth Client Access Token Store**
 
 {{% alert title="Note" %}}
 By default, OAuth uses EhCache instead of Cassandra. For more details on OAuth, see the [API Gateway OAuth User Guide](/bundle/APIGateway_77_OAuthUserGuide_allOS_en_HTML5/).
@@ -246,8 +243,7 @@ startinstance -n "my_gw_server_1" -g "my_group"
 
 1.  Configure the Cassandra consistency levels for your KPS Collections.
     For details, see [Configure the API Gateway Cassandra consistency levels](#configure-the-api-gateway-cassandra-consistency-levels).
-2.  In the Policy Studio tree, select **Server Settings** \> **API
-    Manager** \> **Quota Settings**, and ensure that **Use Cassandra**
+2.  In the Policy Studio tree, select **Server Settings** > **API Manager** > **Quota Settings**, and ensure that **Use Cassandra**
     is selected.
 3.  Under **Cassandra consistency levels**, in both the **Read** and
     **Write** fields, select `QUORUM`:

--- a/content/en/docs/cass_admin/cassandra_manage.md
+++ b/content/en/docs/cass_admin/cassandra_manage.md
@@ -108,10 +108,10 @@ tutorial, you must update the API Gateway Cassandra client configuration
 as follows:
 
 1.  Open the API Gateway group configuration in Policy Studio.
-2.  Select **Server Settings \> Cassandra \> Authentication**, and set
+2.  Select **Server Settings > Cassandra > Authentication**, and set
     the Cassandra username/password (default is
     `cassandra`/`cassandra`).
-3.  Select **Server Settings \> Cassandra \> Hosts**. Add an address for
+3.  Select **Server Settings > Cassandra > Hosts**. Add an address for
     the Cassandra node. You can enter an IP address or host name.
 4.  Deploy the configuration to the API Gateway group.
 

--- a/content/en/docs/central/add_hybrid_env.md
+++ b/content/en/docs/central/add_hybrid_env.md
@@ -141,9 +141,9 @@ Create Kubernetes secrets to hold the mesh agents' public certificates and priva
 
 Usage: `kubectl create secret generic SECRET_NAME --namespace NAMESPACE_NAME  --from-file=publicKey=/PATH/TO/PUBLIC/KEY/FILE --from-file=privateKey=/PATH/TO/PRIVATE/KEY/FILE  --from-file=password=PASSWORD_FILE --from-literal=password=PASSWORD -o yaml`
 
-{{< alert title="Note" color="primary" >}} Each `SECRET_NAME` must match the corresponding SDA or CSA field `keysSecretName` in the `hybridOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit.\
-The SDA default value of `keysSecretName` is `sda-secrets`.\
-The CSA default value of `keysSecretName` is `csa-secrets`.\
+{{< alert title="Note" color="primary" >}} Each `SECRET_NAME` must match the corresponding SDA or CSA field `keysSecretName` in the `hybridOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit.
+The SDA default value of `keysSecretName` is `sda-secrets`.
+The CSA default value of `keysSecretName` is `csa-secrets`.
 To change the secret store names, edit the `keysSecretName` values in the `hybridOverride.yaml` file before you execute the helm upgrade deployment steps.{{< /alert >}}
 
 Example for SDA:

--- a/content/en/docs/contribution_guidelines/writing_markdown.md
+++ b/content/en/docs/contribution_guidelines/writing_markdown.md
@@ -24,6 +24,40 @@ The Blackfriday Markdown parser has some known issues with nested lists. To avoi
 * Always use 4 spaces to indent nested lists. Ensure that tabs are set to 4 spaces in your editor.
 * Do not specify a language for fenced code blocks within a nested list.
 
+### Code samples
+
+* Use 3 or more backticks to open and close a code sample block. You can specify a language after the first set of backticks to easily apply syntax highlighting.
+
+    For example:
+
+        ```md
+        # This is a H1
+
+        This is some text
+
+        ## This is a H2
+
+        This is more text
+        ```
+
+    Renders as:
+
+    ```md
+    # This is a H1
+
+    This is some text
+
+    ## This is a H2
+
+    This is more text
+    ```
+
+* Use single backticks to apply code or monospace formatting to `inline` text.
+
+{{% alert title="Caution" color="warning" %}}
+The Zoomin plugin used when publishing docs to production <https://docs.axway.com> is very sensitive to `<`, `>`, and `\` characters. Ensure that these characters are always enclosed in backticks to have them processed as code instead of as HTML tags.
+{{% /alert %}}
+
 ## Markdown extensions
 
  Hugo and Docsy provide some useful extensions to standard Markdown that you can use to simplify editing and formatting.


### PR DESCRIPTION
- Did a full sanity check and fix of the topic from the zoomin error (removed div tags, various other issues with <, >, / chars.
- Removed or added backticks to any <, >, or \ characters as these are likely to be the cause of zoomin issue as they understood as HTML in some cases and marked red in VSCode.
- Updated the writing markdown topic with tips for code blocks and a warning re using these chars 