### PR TITLE
add JS for docsearch and enable search in config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -80,7 +80,7 @@ github_repo = "https://github.com/Axway/axway-open-docs"
 # github_subdir = ""
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-# gcs_engine_id = "011737558837375720776:fsdu1nryfng"
+gcs_engine_id = "011737558837375720776:fsdu1nryfng"
 
 # User interface configuration
 [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -80,7 +80,10 @@ github_repo = "https://github.com/Axway/axway-open-docs"
 # github_subdir = ""
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "011737558837375720776:fsdu1nryfng"
+# gcs_engine_id = "011737558837375720776:fsdu1nryfng"
+
+# Enable Algolia search
+algolia_docsearch = true
 
 # User interface configuration
 [params.ui]
@@ -89,7 +92,7 @@ sidebar_menu_compact = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 # Set to true to disable the About link in footer

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,5 +1,0 @@
----
-title: Search Results
-layout: search
-
----

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,0 +1,5 @@
+---
+title: Search Results
+layout: search
+
+---

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -2,7 +2,7 @@
 <script type="text/javascript"> docsearch({
 apiKey: '0fe272b76fcdd3184f3bc193bd96ca15',
 indexName: 'axway-open-docs',
-inputSelector: 'form-control td-search-input',
+inputSelector: '.docsearch-input',
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,8 @@
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: '0fe272b76fcdd3184f3bc193bd96ca15',
+indexName: 'axway-open-docs',
+inputSelector: 'form-control td-search-input',
+debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,8 +1,9 @@
+<!-- scripts for algolia docsearch -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
 apiKey: '0fe272b76fcdd3184f3bc193bd96ca15',
 indexName: 'axway-open-docs',
-inputSelector: '.docsearch-input',
+inputSelector: '.td-search-input',
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,1 +1,4 @@
+<!-- code for algolia docsearch -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<!-- override the robots meta in head.html to disable google search -->
+<meta name="robots" content="noindex, nofollow" />

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,3 +1,3 @@
 {{ with .Site.Params.algolia_docsearch }}
- <input type="search" class="docsearch-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+ <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 {{ end }}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,0 +1,3 @@
+{{ with .Site.Params.algolia_docsearch }}
+ <input type="search" class="docsearch-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+{{ end }}


### PR DESCRIPTION
Added the javascript code provided from Algolia DocSearch and got search working in the top nav. The search can be tested on the deploy preview but note that all the search results go to production.

Detailed changes:

- Added the javascript to head end and body end of every page by using the instructions from Docsy https://www.docsy.dev/docs/adding-content/lookandfeel/#add-code-to-head-or-before-body-end
- Create a new search-input.html file in our project - this overrides the same file in the Docsy theme and changes it to use the Algolia search instead of the GCSE
- Added a new param to config.toml for Algolia search so it can be turned on or off easily
- Set the side nav search box to false in config.toml as I couldn't get this search box working with Algolia and anyway I think one search box in top nav is sufficient (could find any other sites apart from Docsy with search in 2 different places)

Edited to add:
I also added code to the head end to tell Google not to crawl the netlify site for the moment (this was a request from Paul as having Google results from both sites could potentially confuse end users)