### PR TITLE
add same lint rules to vscode as for grunt

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+    'default': true,
+    'MD003': {'style': 'atx'},
+    'MD004': {'style': 'asterisk'},
+    'MD007': {'indent': 4},
+    'MD026': {'punctuation': '.,;:!'},
+    'MD029': {'style': 'ordered'},
+    'MD040': false,
+    'MD041': false,
+    'MD046': {'style': 'fenced'},
+}


### PR DESCRIPTION
This config file for markdown lint applies the same rules to vscode as what will be used by grunt in the netlify build (when we enable it)