### PR TITLE
RDAPI_17369: organize menu items order.

### DIFF
--- a/content/en/docs/apigtw_releasenotes/_index.md
+++ b/content/en/docs/apigtw_releasenotes/_index.md
@@ -2,7 +2,7 @@
     "title": "API Gateway 7.8 Release Notes",
     "linkTitle": "API Gateway Release Notes",
     "no_list": "true",
-    "weight": "8",
+    "weight": "15",
     "date": "2019-09-20",
     "description": "Learn about the new features and enhancements in this release."
 }

--- a/content/en/docs/apimng_releasenotes/_index.md
+++ b/content/en/docs/apimng_releasenotes/_index.md
@@ -2,7 +2,7 @@
     "title": "API Manager 7.8 Release Notes",
     "linkTitle": "API Manager Release Notes",
     "no_list": "true",
-    "weight": "8",
+    "weight": "13",
     "date": "2019-09-20",
     "description": "Learn about the new features and enhancements in this release"
 }

--- a/content/en/docs/cass_admin/_index.md
+++ b/content/en/docs/cass_admin/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "API Gateway Apache Cassandra Administrator Guide"
 linkTitle: "Administer Apache Cassandra"
-weight: 9
+weight: 17
 date: 2019-06-05
 description: >
   This guide explains how to configure and manage the Apache Cassandra database


### PR DESCRIPTION
This was just to move APIGTW/MNG release notes right above the Cassandra Admin in the menu.