### PR TITLE
RDAPI-18432 Fix lint errors for APIP, Central, and Cassandra

### DIFF
--- a/content/en/docs/apim_administration/apiportal_admin/customize_APICatalog_overview.md
+++ b/content/en/docs/apim_administration/apiportal_admin/customize_APICatalog_overview.md
@@ -94,8 +94,8 @@ The Try-It button is enabled for all requests to an API by default. To enable or
 1. In JAI, click **Components > API Portal > API Manager**.
 2. In **Try-It Settings**, enable or disable the Try-It button for each request type.
 
-    ![](/Images/uploads/api-manager-try-it-settings.png)
-    
+    ![API Manager try-it](/Images/uploads/api-manager-try-it-settings.png)
+
 3. Click **Save**.
 
 {{% alert title="Note" %}}

--- a/content/en/docs/apim_administration/apiportal_admin/customize_css_styles.md
+++ b/content/en/docs/apim_administration/apiportal_admin/customize_css_styles.md
@@ -32,21 +32,21 @@ When planning changes to CSS files, you can quickly check which file controls th
 {{< alert title="Warning" color="warning">}}It is not recommended to manually edit the `less/themes/axway/variables-custom.less` file. This file contains the attribute values customized in the ThemeMagic editor. For more details, see [Customize with ThemeMagic](/docs/apim_administration/apiportal_admin/customize_getting_started/#customize-with-thememagic).{{< /alert >}}
 
 1. Log in to the Joomla! Admin Interface (JAI), and click **Extensions > Templates**.
-1. In the Template sidebar, click **Templates**, and select **Purity III_Details and Files**.
+2. In the Template sidebar, click **Templates**, and select **Purity III_Details and Files**.
     ![API Portal customizatoin list of available templates through Purity tool](/Images/APIPortal/customation_puritIII_detailsandfiles.png)
-1. On the **Editor** tab, open the following folder:
+3. On the **Editor** tab, open the following folder:
 
     ```
     local/css/themes/<your theme>
     ```
 
-1. Select the `template.less` file containing the element, and locate the correct line. In this example, the value for `text-transform` is changed from `inherit` to `uppercase`.
+4. Select the `template.less` file containing the element, and locate the correct line. In this example, the value for `text-transform` is changed from `inherit` to `uppercase`.
     ![An example screenshot on editing a style css.](/Images/APIPortal/cssjoomlasamplecodechange.png)
-1. Select **Save > Close File**, and close the editor.
-1. In Templates sidebar, select **Styles**.
-1. Select **Purity III - Default**, and click **</> LESS to CSS** to compile a new css file.
+5. Select **Save > Close File**, and close the editor.
+6. In Templates sidebar, select **Styles**.
+7. Select **Purity III - Default**, and click **</> LESS to CSS** to compile a new css file.
     ![Joomla Purity III styles template manager to compile changes to API Portal css](/Images/APIPortal/csspuriistylesconfig.png)
-1. Refresh the API Portal home page in the browser to see your changes.
+8. Refresh the API Portal home page in the browser to see your changes.
 
 ## Add a custom stylesheet
 

--- a/content/en/docs/apim_administration/apiportal_admin/localize_language.md
+++ b/content/en/docs/apim_administration/apiportal_admin/localize_language.md
@@ -18,10 +18,10 @@ User interface strings are stored in language-specific resource files. To add th
 
     ![Install language](/Images/APIPortal/joomla_install_lang.png)
 
-1. Click **Install Languages**.
-1. Find and select the language to install, and click **Install**.
-1. After the installation is finished, click **Extensions > Language(s) > Installed** and ensure that **Site** is selected at the top of the page.
-1. To set the installed language as the default language of your API Portal, click the star button in the row for that language.
+2. Click **Install Languages**.
+3. Find and select the language to install, and click **Install**.
+4. After the installation is finished, click **Extensions > Language(s) > Installed** and ensure that **Site** is selected at the top of the page.
+5. To set the installed language as the default language of your API Portal, click the star button in the row for that language.
 
     {{< alert title="Tip" color="primary" >}}You can change the default language of JAI independently from your API Portal. Select **Administrator** on the **Languages: Installed** page and click the star button in the row for the required language. You can also select any of the installed languages when you log in to JAI.{{< /alert >}}
 
@@ -56,13 +56,13 @@ To install the translated file:
 
     `/opt/axway/apiportal/htdoc/language/en-GB/en-GB.com_apiportal.ini`
 
-1. Go to resource file directory of the language you installed (for example, `/opt/axway/apiportal/htdoc/language/fr-FR/`), and paste the copied file there.
-1. Rename the copied `.ini` file to match the language code of the installed language (for example, `fr-FR.com_apiportal.ini`).
-1. Open both the English `.ini` file and the copied `.ini` file.
-1. In the English `.ini` file, find a UI text you want to change (such as the text `Connect with a community of developers` at the bottom of the API Portal sign in page), and copy the UI string ID (`COM_APIPORTAL_HOME_CONNECT`).
-1. In the copied `.ini` file, find the same UI string, and change the value of the string to the new language translation.
-1. Repeat the last two steps for all the UI strings on all your API Portal pages that you want to change to the new language, and save the file.
-1. Go to your API Portal, refresh the page, and verify that the UI texts have changed to your new language.
+2. Go to resource file directory of the language you installed (for example, `/opt/axway/apiportal/htdoc/language/fr-FR/`), and paste the copied file there.
+3. Rename the copied `.ini` file to match the language code of the installed language (for example, `fr-FR.com_apiportal.ini`).
+4. Open both the English `.ini` file and the copied `.ini` file.
+5. In the English `.ini` file, find a UI text you want to change (such as the text `Connect with a community of developers` at the bottom of the API Portal sign in page), and copy the UI string ID (`COM_APIPORTAL_HOME_CONNECT`).
+6. In the copied `.ini` file, find the same UI string, and change the value of the string to the new language translation.
+7. Repeat the last two steps for all the UI strings on all your API Portal pages that you want to change to the new language, and save the file.
+8. Go to your API Portal, refresh the page, and verify that the UI texts have changed to your new language.
 
 ### Change the text overrides on the sign in page
 
@@ -115,16 +115,16 @@ You must duplicate the API Portal main menu for each language.
 
     ![Joomla Main Menu](/Images/APIPortal/joomla_main_menu.png)
 
-1. To clone all the menu items at once, click the Check All Items check box and click **Batch**.
-1. In **Set Language**, select the correct content language.
-1. In **To Move or Copy**, locate the correct main menu for the language and select **Add to this menu**.
-1. Select **Copy** to make a copy of the menu items.
-1. Click **Process**.
-1. In the JAI top navigation bar, click **Menus** and select the main menu you cloned the menu items to.
-1. To set the default home page, click the star in the row for the **Home** menu item.
-1. To rename the cloned menu items, click each menu item to edit it, and change **Menu Title** to the correct translation (for example, `Home(2)` to `Accueil`).
-1. Click **Save & Close**.
-1. Repeat for each menu item.
+2. To clone all the menu items at once, click the Check All Items check box and click **Batch**.
+3. In **Set Language**, select the correct content language.
+4. In **To Move or Copy**, locate the correct main menu for the language and select **Add to this menu**.
+5. Select **Copy** to make a copy of the menu items.
+6. Click **Process**.
+7. In the JAI top navigation bar, click **Menus** and select the main menu you cloned the menu items to.
+8. To set the default home page, click the star in the row for the **Home** menu item.
+9. To rename the cloned menu items, click each menu item to edit it, and change **Menu Title** to the correct translation (for example, `Home(2)` to `Accueil`).
+10. Click **Save & Close**.
+11. Repeat for each menu item.
 
 ### Duplicate the page template styles
 
@@ -175,9 +175,9 @@ To enable a language switcher, you need to have a main menu for each language yo
 
 After following this process you will have the following main menus:
 
-- Main menu - All
-- Main menu - FR
-- Main menu - EN
+* Main menu - All
+* Main menu - FR
+* Main menu - EN
 
 #### Create a main menu for all languages
 
@@ -236,9 +236,9 @@ To enable a language switcher, you need to have template styles for each languag
 
 By default, API Portal uses the Purity III template style. After following this process you will have the following template styles:
 
-- purity_III - Default - English
-- purity_III - Default - French
-- purity_III - Default - All
+* purity_III - Default - English
+* purity_III - Default - French
+* purity_III - Default - All
 
 #### Duplicate the template style for the new language
 
@@ -246,13 +246,13 @@ By default, API Portal uses the Purity III template style. After following this
 
     ![Joomla Templates Styles](/Images/APIPortal/joomla_templates_styles.png)
 
-1. Click your template style (for example, `purity_III - Default`) to open it.
-1. Click the arrow next to the **Save** button at the top left of the window, and select **Save as Copy**.
-1. Edit the **Style Name** to indicate the language (for example, `purity_III - Default - French`).
-1. Select the respective language as the **Default**. This sets this template as the default for pages using the selected language.
-1. Click the **Navigation** tab, and change the **Menu** to the correct main menu for the language.
-1. Click the **Assignment** tab, and assign the menu items from the correct language to the template. To select or deselect all menu items, click the toggle button next to the main menu title.
-1. Click **Save** and click **Close** to close the template style.
+2. Click your template style (for example, `purity_III - Default`) to open it.
+3. Click the arrow next to the **Save** button at the top left of the window, and select **Save as Copy**.
+4. Edit the **Style Name** to indicate the language (for example, `purity_III - Default - French`).
+5. Select the respective language as the **Default**. This sets this template as the default for pages using the selected language.
+6. Click the **Navigation** tab, and change the **Menu** to the correct main menu for the language.
+7. Click the **Assignment** tab, and assign the menu items from the correct language to the template. To select or deselect all menu items, click the toggle button next to the main menu title.
+8. Click **Save** and click **Close** to close the template style.
 
 #### Duplicate the template style for all languages
 
@@ -296,11 +296,11 @@ By default, API Portal uses the date-month-year (like "10 Mar 2017") format for
 
 The following list provides some examples on formats and their outputs:
 
-- `m.d.y` — 03.10.17
-- `j, n, Y` — 10, 3, 2017
-- `Ymd` — 20170310
-- `F j, Y, g:i a` — March 10, 2017, 5:16 pm
-- `D M j G:i:s T Y` — Fri Mar 10 17:16:18 UCT 2017
-- `g:i a` — 5:16 pm
-- `H:i:s` — 17:16:18
-- `Y-m-d H:i:s` — 2017-03-10 17:16:18 (the MySQL DATETIME format)
+* `m.d.y` — 03.10.17
+* `j, n, Y` — 10, 3, 2017
+* `Ymd` — 20170310
+* `F j, Y, g:i a` — March 10, 2017, 5:16 pm
+* `D M j G:i:s T Y` — Fri Mar 10 17:16:18 UCT 2017
+* `g:i a` — 5:16 pm
+* `H:i:s` — 17:16:18
+* `Y-m-d H:i:s` — 2017-03-10 17:16:18 (the MySQL DATETIME format)

--- a/content/en/docs/apim_administration/apiportal_admin/public_api_configure.md
+++ b/content/en/docs/apim_administration/apiportal_admin/public_api_configure.md
@@ -18,9 +18,9 @@ The user experience in public API mode is different than when signed in:
 
 * On the API Portal landing page, the Sign In button is replaced with an Explore button that goes to API Catalog.
 * The items in the main navigation menu have the following changes:
-  * API Catalog displays only the APIs and methods configured to be exposed in Public API mode, but is available normally.
-  * If not disabled, the Applications page is available as read-only. The Usage tab on the Applications page is always disabled.
-  * The Monitoring and Users pages are unavailable.
+    * API Catalog displays only the APIs and methods configured to be exposed in Public API mode, but is available normally.
+    * If not disabled, the Applications page is available as read-only. The Usage tab on the Applications page is always disabled.
+    * The Monitoring and Users pages are unavailable.
 * The user profile information is unavailable.
 
 Public API mode only affects your APIs and applications. Joomla! articles, blogs, or forums are not included in Public API mode. You can manage how these are exposed by changing their **Access** settings in JAI.
@@ -30,21 +30,21 @@ Public API mode only affects your APIs and applications. Joomla! articles, blogs
 For Public API mode access, create a separate organization and user in API Manager, and give that organization access to any APIs and applications that you want to expose publicly.
 
 1. In API Manager, add a new organization (for example, `Public API Org`).
-1. Add a user account for Public API mode access.
+2. Add a user account for Public API mode access.
 
     * Enable the user.
     * Set **Organization** to the Public API organization you created (`Public API Org`)
     * Set **Role** to `User`.
 
-1. Select **Change password**, and set the password for the Public API mode user.
+3. Select **Change password**, and set the password for the Public API mode user.
 
     Make a note of the login name and password you configure for the Public API mode user. You will need them later when configuring the Public API mode in JAI.
 
-1. Select the APIs to expose publicly. Go to **Frontend API**, select the APIs to expose (they must be in **Published** state), click **Managed selected > Grant access**, set **Grant API access** to **The following organizations**, and add and select your Public API mode organization.
+4. Select the APIs to expose publicly. Go to **Frontend API**, select the APIs to expose (they must be in **Published** state), click **Managed selected > Grant access**, set **Grant API access** to **The following organizations**, and add and select your Public API mode organization.
 
     {{< alert title="Tip" >}} You can import two versions of a back-end API: one that contains only non-business critical information and is exposed in Public API mode, and a full version which is not exposed without a user login. {{< /alert >}}
 
-1. Select the applications to expose publicly. Go to **Clients > Applications**, ensure that the organization of the applications is set to your Public API mode organization and the application has access to the required APIs, then share the application with the Public API mode user you created. It is recommended to only provide rights to view the application.
+5. Select the applications to expose publicly. Go to **Clients > Applications**, ensure that the organization of the applications is set to your Public API mode organization and the application has access to the required APIs, then share the application with the Public API mode user you created. It is recommended to only provide rights to view the application.
 
 ## Enable Public API mode in API Portal
 

--- a/content/en/docs/apim_administration/apiportal_admin/role_mapping.md
+++ b/content/en/docs/apim_administration/apiportal_admin/role_mapping.md
@@ -28,15 +28,20 @@ This section describes the user groups mapping table, available from **Component
 
 The table consists of five columns: **Roles**, **Org. Admin**, **Developer**, **Organizations**, **Email Pattern**.
 
-**Roles** - Displays all the Joomla! user groups.
+**Roles**
+: Displays all the Joomla! user groups.
 
-**Org. Admin** - Represents the API Manager **Organization Admin** role. Check this box to map API Manager Organization Admin role to the corresponding Joomla! user group.
+**Org. Admin**
+: Represents the API Manager **Organization Admin** role. Check this box to map API Manager Organization Admin role to the corresponding Joomla! user group.
 
-**Developer** - Represents the API Manager **User** role. Check this box to map the API Manager User role to the corresponding Joomla! user group.
+**Developer**
+: Represents the API Manager **User** role. Check this box to map the API Manager User role to the corresponding Joomla! user group.
 
-**Organizations** - Allows you to map all users from one or more API Manager organizations to a Joomla! user group. You can add, edit, and delete organizations. This field supports `*` and `?` wildcards. For example, `myorg*` will map all users that are part of `myorg`, `myorgs`, `myorganization`, and so on.
+**Organizations**
+: Allows you to map all users from one or more API Manager organizations to a Joomla! user group. You can add, edit, and delete organizations. This field supports `*` and `?` wildcards. For example, `myorg*` will map all users that are part of `myorg`, `myorgs`, `myorganization`, and so on.
 
-**Email Pattern** - Allows you to map all users with a given text in their email domain to a Joomla! user group. You can add, edit, and delete email domains. This field supports `" "` (blank space) and `?` wildcard. For example, `@mail.com` will map all users whose email domain is `mail`.
+**Email Pattern**
+: Allows you to map all users with a given text in their email domain to a Joomla! user group. You can add, edit, and delete email domains. This field supports `" "` (blank space) and `?` wildcard. For example, `@mail.com` will map all users whose email domain is `mail`.
 
 ![User groups mapping table](/Images/APIPortal/role_mapping_expanded.png)
 

--- a/content/en/docs/apim_administration/apiportal_admin/sso/sso_config.md
+++ b/content/en/docs/apim_administration/apiportal_admin/sso/sso_config.md
@@ -12,9 +12,9 @@ description: Configure single sign-on (SSO) and enable it for your API Portal us
 * The IdP posts SAML assertions to API Portal. When configuring the IDP for a new API Portal client, you must set the post back addresses to API Portal.
 * You must always use fully qualified domain names (FQDNs) for the host name. Avoid using IP addresses or `localhost` in the configuration.
 * The following prerequisites apply to organizations in API Manager:
-  * Before a user can authenticate successfully using SSO, the API Portal organization associated with the SSO user must exist.
-  * An API Manager administrator user can add the organizations in advance.
-  * When configuring the file `service-provider-apiportal.xml`, ensure that the SSO user only ever belongs to one organization.
+    * Before a user can authenticate successfully using SSO, the API Portal organization associated with the SSO user must exist.
+    * An API Manager administrator user can add the organizations in advance.
+    * When configuring the file `service-provider-apiportal.xml`, ensure that the SSO user only ever belongs to one organization.
 
 ## Configuration files
 

--- a/content/en/docs/apim_administration/apiportal_admin/sso/sso_mapping.md
+++ b/content/en/docs/apim_administration/apiportal_admin/sso/sso_mapping.md
@@ -24,53 +24,67 @@ Two types of mappings are supported:
 Following are the attributes expected by API Portal, and  examples of mappings that you can use to provide them.
 
 * `name` (mandatory)
-  * The logged in user name.
-  * Sample RenameMapping if the IdP provides an attribute which should be renamed:
+    * The logged in user name.
+    * Sample RenameMapping if the IdP provides an attribute which should be renamed:
     `<RenameMapping source="user" target="name"/>`
 
 * `organization` (mandatory)
-  * The API Portal organization associated with the logged in user. The organization must already exist in API Portal. Organizations can be added by an API Manager administrator in API Manager.
-  * The IdP does not need to provide this value. 
+    * The API Portal organization associated with the logged in user. The organization must already exist in API Portal. Organizations can be added by an API Manager administrator in API Manager.
+    * The IdP does not need to provide this value.
   
         If it does and the IdP attribute has a different name, you can use a RenameMapping to transform it to an organization attribute.
 
         If the IdP does not provide the value associated with the organization at all, you can use an OutputAttribute to assign an organization to the logged in user. For example:
 
-        `<OutputAttribute name="organization">Research</OutputAttribute>`
+        ```
+        <OutputAttribute name="organization">Research</OutputAttribute>
+        ```
 
 * `role` (mandatory)
-  * The API Portal role associated with the logged in user. Permitted substring values: `Operator`, `User`.
-  * The IdP does not need to provide this value.
+    * The API Portal role associated with the logged in user. Permitted substring values: `Operator`, `User`.
+    * The IdP does not need to provide this value.
 
         If it does and the IdP attribute has a different name, you can use a RenameMapping to transform it to a role attribute.
-        
-        If the IDP does not provide the value associated with the role at all, you can use an OutputAttribute to assign a role to the logged in user. For example: 
-        
-        `<OutputAttribute name="role">Operator</OutputAttribute>`
+
+        If the IDP does not provide the value associated with the role at all, you can use an OutputAttribute to assign a role to the logged in user. For example:
+
+        ```
+        <OutputAttribute name="role">Operator</OutputAttribute>
+        ```
 
 * `mail` (optional)
-  * The email address associated with the logged in user.
-  * Sample RenameMapping if the IdP provides an attribute which should be renamed:
-    `<RenameMapping source="email" target="mail"/>`
+    * The email address associated with the logged in user.
+    * Sample RenameMapping if the IdP provides an attribute which should be renamed:
+
+    ```
+    <RenameMapping source="email" target="mail"/>
+    ```
 
 * `description` (optional)
-  * The description text associated with the logged in user.
-  * Sample RenameMapping if the IdP provides an attribute which should be renamed:
-    `<RenameMapping source="userDescription" target="description"/>`
+    * The description text associated with the logged in user.
+    * Sample RenameMapping if the IdP provides an attribute which should be renamed:
+
+    ```
+    <RenameMapping source="userDescription" target="description"/>`
+    ```
 
 * `department` (optional)
-  * The department that the logged in user belongs to.
-  * Sample RenameMapping if the IdP provides an attribute which should be renamed:
-    `<RenameMapping source="businessUnit" target="department"/>`
+    * The department that the logged in user belongs to.
+    * Sample RenameMapping if the IdP provides an attribute which should be renamed:
+
+    ```
+    <RenameMapping source="businessUnit" target="department"/>
+    ```
 
 * `telephonenumber` (optional)
-  * The telephone number associated with the logged in user.
-  * Sample RenameMapping if the IdP provides an attribute which should be renamed:
-    `<RenameMapping source="phone" target="telephonenumber"/>`
+    * The telephone number associated with the logged in user.
+    * Sample RenameMapping if the IdP provides an attribute which should be renamed:
 
-{{< alert title="Note" >}}
-API Portal attribute names are all lowercase. The attribute names are case-sensitive.
-{{< /alert >}}
+    ```
+    <RenameMapping source="phone" target="telephonenumber"/>
+    ```
+
+{{< alert title="Note" >}}API Portal attribute names are all lowercase. The attribute names are case-sensitive. {{< /alert >}}
 
 ### Rename mapping example
 
@@ -100,6 +114,7 @@ In addition, a filter mapping is used to achieve the following:
 * If a user logs in with the transformed `mail` attribute set to `sjones@research.activedirectory2012.lab.chicago.acme.int` the user is assigned a `role` of `User` and an `organization` of `Research`.
 
 For example:
+
 ```
 <Mappings>
     <RenameMapping source="phone" target="telephonenumber"/>
@@ -178,26 +193,26 @@ This element describes the certificate validation. You can configure certificate
 The following attributes are supported:
 
 * `pathValidation`
-  * If set to `true`, the certification path for each certificate will be checked. If set to `false`, the agent verifies only the validity period of each certificate. 
-  * A trust store must be specified if this attribute is `true`.
+    * If set to `true`, the certification path for each certificate will be checked. If set to `false`, the agent verifies only the validity period of each certificate.
+    * A trust store must be specified if this attribute is `true`.
 
 * `enableRevocation`
-  * If set to `true`, the agent also verifies if the certificates are not revoked.
+    * If set to `true`, the agent also verifies if the certificates are not revoked.
 
 * `trustStorePath`
-  * If set to `true`, the agent also verifies if the certificates are not revoked.
+    * If set to `true`, the agent also verifies if the certificates are not revoked.
 
 * `trustStorePassword`
-  * The password to access the trust store.
+    * The password to access the trust store.
 
 * `intermediateStorePath`
-  * The path to a store containing intermediate certificates that can appear in certificate chains.
+    * The path to a store containing intermediate certificates that can appear in certificate chains.
 
 * `intermediateStorePassword`
-  * The password to access the intermediate certificates store.
+    * The password to access the intermediate certificates store.
 
 * `delayBetweenValidations`
-  * Defines at which interval certificate validation occurs, in hours.
+    * Defines at which interval certificate validation occurs, in hours.
 
 To disable certificate validation, set `pathValidation` to false. For example:
 
@@ -215,50 +230,50 @@ This element describes the SP.
 The following attributes are supported:
 
 * `entityId`
-  * Sets the unique identifier of the SP. This identifier is sent to the IdP so it can know who is requesting an authentication or logging out. 
-  * The default value is `api-portal`. The same value must also be set in the Joomla! Administrator Interface (JAI), see [Enable SSO in API Portal](/docs/apim_administration/apiportal_admin/sso/sso_config/#enable-sso-in-api-portal)
+    * Sets the unique identifier of the SP. This identifier is sent to the IdP so it can know who is requesting an authentication or logging out.
+    * The default value is `api-portal`. The same value must also be set in the Joomla! Administrator Interface (JAI), see [Enable SSO in API Portal](/docs/apim_administration/apiportal_admin/sso/sso_config/#enable-sso-in-api-portal)
 
 * `excludeHostInEndpointURICheck`
-  * An endpoint URI check examines the intended destination endpoint as determined by the IdP and the actual receiver endpoint for a message. In other words, where the message was intended and where it was actually delivered.
-  * By default, the check mandates that these two values must match exactly. However, in the case of reverse proxying, the message destination endpoint server forwards the messages on for processing to another server, and the check must be relaxed slightly.
-  * This setting specifies if that the host name in the message destination endpoint is not checked although the path is checked. Set this value to true.
+    * An endpoint URI check examines the intended destination endpoint as determined by the IdP and the actual receiver endpoint for a message. In other words, where the message was intended and where it was actually delivered.
+    * By default, the check mandates that these two values must match exactly. However, in the case of reverse proxying, the message destination endpoint server forwards the messages on for processing to another server, and the check must be relaxed slightly.
+    * This setting specifies if that the host name in the message destination endpoint is not checked although the path is checked. Set this value to true.
 
 * `relaxedEndpointURICheckHostDetails`
-  * This setting defines a CSV list of hosts that the host in the message destination endpoint is checked against.
-  * This setting is optional. If you do not intend to use this, delete this attribute from the configuration file. This configuration is less secure but more flexible.
-  * If you include the list of safe hosts, include the host details of your API Portal (`https://<FQDN>:<port>`) in the list. The endpoint URI check succeeds only if the host name in the message destination endpoint is on the list.
+    * This setting defines a CSV list of hosts that the host in the message destination endpoint is checked against.
+    * This setting is optional. If you do not intend to use this, delete this attribute from the configuration file. This configuration is less secure but more flexible.
+    * If you include the list of safe hosts, include the host details of your API Portal (`https://<FQDN>:<port>`) in the list. The endpoint URI check succeeds only if the host name in the message destination endpoint is on the list.
 
 * `useAppSessions`
-  * Delegates the session management to the application. The default value is `true`.
+    * Delegates the session management to the application. The default value is `true`.
 
 * `filteredUri`
-  * Specifies the URI of the SSO filter entry point for authentication. Set this value to `/sso/externallogin`.
-  * The SSO filter only manages login URI, for other requests the application must redirect to SSO filter to manage authentication. * If the user is not authenticated, a SAML authentication request is built and sent to the IdP. Otherwise, the security token is forwarded to the application.
+    * Specifies the URI of the SSO filter entry point for authentication. Set this value to `/sso/externallogin`.
+    * The SSO filter only manages login URI, for other requests the application must redirect to SSO filter to manage authentication. * If the user is not authenticated, a SAML authentication request is built and sent to the IdP. Otherwise, the security token is forwarded to the application.
 
 * `logoutUri`
-  * Specifies the URI of the SSO filter entry point for logout process. Set this value to `/sso/externallogout`.
+    * Specifies the URI of the SSO filter entry point for logout process. Set this value to `/sso/externallogout`.
 
 * `logoutRedirectUri`
-  * Specifies the URI of the SSO filter entry point for logout process. Set this value to `/sso/externallogout`.
-  * The SSO filter generates a logout request and sends it to the IdP.
+    * Specifies the URI of the SSO filter entry point for logout process. Set this value to `/sso/externallogout`.
+    * The SSO filter generates a logout request and sends it to the IdP.
 
 * `logoutRedirectUri`
-  * Specifies the URI where to redirect after the logout process. Set this value to `/api/portal/v1.3/sso/proxylogout`.
+    * Specifies the URI where to redirect after the logout process. Set this value to `/api/portal/v1.3/sso/proxylogout`.
 
 * `keystore`
-  * Specifies the name of a keystore where the private key of the SP is stored. The default value is `conf/sso.jks`.
-  * The SP uses the private key to decrypt messages from the IdP that the IdP has encrypted with the SP's public key. If the IdP does not encrypt the messages, the keystore can be omitted.
-  * When you set this attribute, the `keystorePassphrase` and `keyAlias` attributes must also be set.
-  * The keystore must be in the `classpath` of the application or in its working directory. The keystore format must be `.jks`.
+    * Specifies the name of a keystore where the private key of the SP is stored. The default value is `conf/sso.jks`.
+    * The SP uses the private key to decrypt messages from the IdP that the IdP has encrypted with the SP's public key. If the IdP does not encrypt the messages, the keystore can be omitted.
+    * When you set this attribute, the `keystorePassphrase` and `keyAlias` attributes must also be set.
+    * The keystore must be in the `classpath` of the application or in its working directory. The keystore format must be `.jks`.
 
 * `keystorePassphrase`
-  * Specifies the password of the keystore, if a password is set.
+    * Specifies the password of the keystore, if a password is set.
 
 * `keyAlias`
-  * Specifies the alias of the SP's private key in the keystore, if an alias is set.
+    * Specifies the alias of the SP's private key in the keystore, if an alias is set.
 
 * `sessionIdCookieName`
-  * Sets the name of the cookie where the SSO session identifier is stored if the SSO module is the session manager. The recommended value is `spExternalSSOSessionId3`.
+    * Sets the name of the cookie where the SSO session identifier is stored if the SSO module is the session manager. The recommended value is `spExternalSSOSessionId3`.
 
 ### `<AssertionConsumerService>`
 
@@ -273,17 +288,17 @@ This element specifies the IdP URL where the logout responses are sent. Only `HT
 This element describes the entity that exchanges SAML messages with the SSO filter. This section contains a section called `<SamlIdentityProvider>`, which supports the following attributes:
 
 * `entityId` and `format`
-  * Sets the unique identifier of the IdP. These values must match the `entityId` and `format` values of the Issuer element in the SAML assertions.
+    * Sets the unique identifier of the IdP. These values must match the `entityId` and `format` values of the Issuer element in the SAML assertions.
 
 * `metadataUrl`
-  * Specifies the URL of the metadata file. The default value is `./idp.xml`.
+    * Specifies the URL of the metadata file. The default value is `./idp.xml`.
 
 * `userNameAttribute`
-  * Specifies the name of the IdP attribute that provides the user name. The default value is `urn:oid:2.5.4.42`.
-  * When a user is authenticated, the SSO filter sets a principal on the `HttpServletRequest`. By default, the name of this principal is extracted from the `Subject` element in the assertions of an authentication response. If `userNameAttribute` is set, the name of the principal is set to the value of the specified IdP attribute
+    * Specifies the name of the IdP attribute that provides the user name. The default value is `urn:oid:2.5.4.42`.
+    * When a user is authenticated, the SSO filter sets a principal on the `HttpServletRequest`. By default, the name of this principal is extracted from the `Subject` element in the assertions of an authentication response. If `userNameAttribute` is set, the name of the principal is set to the value of the specified IdP attribute
 
 * `verifyAssertionExpiration`
-  * Verifies the validity period of a SAML assertion. The default value is `true`.
+    * Verifies the validity period of a SAML assertion. The default value is `true`.
 
 ### `<Mappings>`
 

--- a/content/en/docs/apim_installation/apiportal_install/installConfigure.md
+++ b/content/en/docs/apim_installation/apiportal_install/installConfigure.md
@@ -14,10 +14,14 @@ For details on how to configure the look and feel of your API Portal end-user i
 
 To modify the API Portal *Terms & Conditions* content, edit the following file:
 
-`/opt/axway/apiportal/htdoc/components/com_apiportal/views/terms/tmpl/default.php`
+```
+/opt/axway/apiportal/htdoc/components/com_apiportal/views/terms/tmpl/default.php
+```
 
 ## Configure copyright notice
 
 To customize the copyright notice that is displayed at the bottom of the API Portal pages, edit the following file:
 
-`/opt/axway/apiportal/htdoc/templates/purity_iii/tpls/blocks/footer.php`
+```
+/opt/axway/apiportal/htdoc/templates/purity_iii/tpls/blocks/footer.php
+```

--- a/content/en/docs/apim_installation/apiportal_install/install_dependencies.md
+++ b/content/en/docs/apim_installation/apiportal_install/install_dependencies.md
@@ -18,21 +18,21 @@ To install PHP 7.x, you can use an additional official RHEL repository. By defau
 
 1. Add an official RHEL repository that contains PHP version 7.x:
 
-```
-$ sudo subscription-manager repos --enable rhel-server-rhscl-7-rpms
-```
+    ```
+    sudo subscription-manager repos --enable rhel-server-rhscl-7-rpms
+    ```
 
-1. Clear the cache:
+2. Clear the cache:
 
-```
-$ sudo yum clean all
-```
+    ```
+    sudo yum clean all
+    ```
 
-1. Run the update:
+3. Run the update:
 
-```
-$ sudo yum update
-```
+    ```
+    sudo yum update
+    ```
 
 ### Install PHP from official RHEL repository
 
@@ -40,15 +40,15 @@ $ sudo yum update
 
 1. To find the latest PHP7 version, enter the following command:
 
-```
-$ sudo yum search php7
-```
+    ```
+    sudo yum search php7
+    ```
 
-1. Install all required packages, for example:
+2. Install all required packages, for example:
 
-```
-$ sudo yum install rh-php71 rh-php71-php rh-php71-php-cli rh-php71-php-common rh-php71-php-gd rh-php71-php-json rh-php71-php-intl rh-php71-php-mbstring rh-php71-php-mysqlnd rh-php71-php-pdo rh-php71-php-xml rh-php71-php-zip
-```
+    ```
+    sudo yum install rh-php71 rh-php71-php rh-php71-php-cli rh-php71-php-common rh-php71-php-gd rh-php71-php-json rh-php71-php-intl rh-php71-php-mbstring rh-php71-php-mysqlnd rh-php71-php-pdo     rh-php71-php-xml rh-php71-php-zip
+    ```
 
 ### Create symbolic link
 
@@ -56,23 +56,23 @@ After installation, create a symbolic link to use PHP directly in a terminal:
 
 1. Check that PHP is located in the directory `/opt/rh/rh-php71/root/usr/bin/php` and execute the following command to verify the PHP version:
 
-```
-$ /opt/rh/rh-php71/root/usr/bin/php -v
-PHP 7.1.8 (cli) (built: Nov 7 2018 18:12:07) (NTS)
-```
+    ```
+    /opt/rh/rh-php71/root/usr/bin/php -v
+    PHP 7.1.8 (cli) (built: Nov 7 2018 18:12:07) (NTS)
+    ```
 
-1. To create a symbolic link, enter the command:
+2. To create a symbolic link, enter the command:
 
-```
-$ ln -s /opt/rh/rh-php71/root/usr/bin/php /usr/bin/php
-```
+    ```
+    ln -s /opt/rh/rh-php71/root/usr/bin/php /usr/bin/php
+    ```
 
-1. Run the following to validate the symbolic link was created successfully:
+3. Run the following to validate the symbolic link was created successfully:
 
-```
-$ php –v
-PHP 7.1.8 (cli) (built: Nov 7 2018 18:12:07) (NTS)
-```
+    ```
+    php –v
+    PHP 7.1.8 (cli) (built: Nov 7 2018 18:12:07) (NTS)
+    ```
 
 ### Upgrade PHP
 
@@ -85,7 +85,7 @@ If Apache is not already installed, skip this section and follow the steps in [I
 Depending on your existing Apache installation, you might need to configure Apache. Use the following command to check your existing Apache package:
 
 ```
-$ rpm -qa | grep httpd
+rpm -qa | grep httpd
 ```
 
 Follow the appropriate steps for your version (`httpd-2.4.*` or `httpd24-httpd-2.4.*`).
@@ -95,13 +95,13 @@ Follow the appropriate steps for your version (`httpd-2.4.*` or `httpd24-httpd-2
 By default, Apache does not use the newly installed PHP, so you must perform some additional configuration steps. The following steps apply to the default Apache 2.4 (for example, `yum install httpd`) only.
 
 1. Open the file `/etc/httpd/conf/httpd.conf`.
-1. Above the line `Include conf.modules.d/*`, remove any existing entry for PHP and add the line:
+2. Above the line `Include conf.modules.d/*`, remove any existing entry for PHP and add the line:
 
-```
-LoadModule php7_module /opt/rh/httpd24/root/usr/lib64/httpd/modules/librh-php71-php7.so
-```
+    ```
+    LoadModule php7_module /opt/rh/httpd24/root/usr/lib64/httpd/modules/librh-php71-php7.so
+    ```
 
-1. Add `index.php` to the `<IfModule dir_module>` directive. For example, change:
+3. Add `index.php` to the `<IfModule dir_module>` directive. For example, change:
 
     ```
     <IfModule dir_module>
@@ -117,44 +117,44 @@ LoadModule php7_module /opt/rh/httpd24/root/usr/lib64/httpd/modules/librh-php71-
     </IfModule>
     ```
 
-1. Add the following after the `<IfModule dir_module>` directive:
+4. Add the following after the `<IfModule dir_module>` directive:
 
-```
-# Allow php to handle Multiviews
-    AddType text/html .php
-    # mod_php options
-    <IfModule  mod_php7.c>
-        # Cause the PHP interpreter to handle files with a .php extension.
-        <FilesMatch \.php$>
-            SetHandler application/x-httpd-php
-        </FilesMatch>
-        # Uncomment the following lines to allow PHP to pretty-print .phps
-        # files as PHP source code:
-        #<FilesMatch \.phps$>
-        #    SetHandler application/x-httpd-php-source
-        #</FilesMatch>
-        # Apache specific PHP configuration options
-        # those can be override in each configured vhost
-        #
-        php_value session.save_handler "files"
-        php_value session.save_path    "/var/opt/rh/rh-php71/lib/php/session"
-        php_value soap.wsdl_cache_dir  "/var/opt/rh/rh-php71/lib/php/wsdlcache"
-        #php_value opcache.file_cache   "/var/opt/rh/rh-php71/lib/php/opcache"
-    </IfModule>
-```
+    ```
+    # Allow php to handle Multiviews
+        AddType text/html .php
+        # mod_php options
+        <IfModule  mod_php7.c>
+            # Cause the PHP interpreter to handle files with a .php extension.
+            <FilesMatch \.php$>
+                SetHandler application/x-httpd-php
+            </FilesMatch>
+            # Uncomment the following lines to allow PHP to pretty-print .phps
+            # files as PHP source code:
+            #<FilesMatch \.phps$>
+            #    SetHandler application/x-httpd-php-source
+            #</FilesMatch>
+            # Apache specific PHP configuration options
+            # those can be override in each configured vhost
+            #
+            php_value session.save_handler "files"
+            php_value session.save_path    "/var/opt/rh/rh-php71/lib/php/session"
+            php_value soap.wsdl_cache_dir  "/var/opt/rh/rh-php71/lib/php/wsdlcache"
+            #php_value opcache.file_cache   "/var/opt/rh/rh-php71/lib/php/opcache"
+        </IfModule>
+    ```
 
-1. Save the file and restart Apache:
+5. Save the file and restart Apache:
 
-```
-$ systemctl restart httpd
-```
+    ```
+    systemctl restart httpd
+    ```
 
 #### Configure existing Apache (httpd24-httpd-2.4.*)
 
 This package does not require any additional configuration for PHP.
 
-- You do not have to perform any additional steps if you have installed `httpd24-httpd` (and `httpd24-mod_ssl`) and want to use `rh-php71`.
-- If you are using the newer Apache (for example, `yum install httpd24-httpd`) its configuration files are usually located in `/opt/rh/httpd24/root/etc/httpd/`.
+* You do not have to perform any additional steps if you have installed `httpd24-httpd` (and `httpd24-mod_ssl`) and want to use `rh-php71`.
+* If you are using the newer Apache (for example, `yum install httpd24-httpd`) its configuration files are usually located in `/opt/rh/httpd24/root/etc/httpd/`.
 
 ### Install Apache and PHP from official RHEL repository
 
@@ -166,39 +166,39 @@ Follow these steps to install Apache and PHP from the Red Hat Software Collectio
 2. If you have Apache already, remove it:
 
     ```
-    $ yum remove httpd
+    yum remove httpd
     ```
 
 3. Install the packages:
 
-```
-$ yum install httpd24-httpd httpd24-httpd-tools httpd24-mod_ssl
-```
+    ```
+    yum install httpd24-httpd httpd24-httpd-tools httpd24-mod_ssl
+    ```
 
-1. Verify you have the package `httpd24-httpd` with the command:
+4. Verify you have the package `httpd24-httpd` with the command:
+
+    ```
+    pm -qa  grep httpd24-httpd
+    ```
+
+5. Create a symbolic link:
+
+    ```
+    ln -sf /opt/rh/httpd24/root/sbin/httpd /usr/bin/httpd
+    ```
+
+6. Restart the terminal to enable the symbolic link.
+7. Verify:
+
+    ```
+    httpd -v
+    ```
+
+8. Perform the steps in [Install PHP from official RHEL repository](#install-php-from-official-rhel-repository).
+9. Restart Apache:
 
 ```
-$ rpm -qa  grep httpd24-httpd
-```
-
-1. Create a symbolic link:
-
-```
-$ ln -sf /opt/rh/httpd24/root/sbin/httpd /usr/bin/httpd 
-```
-
-1. Restart the terminal to enable the symbolic link.
-1. Verify:
-
-```
-$ httpd -v
-```
-
-1. Perform the steps in [Install PHP from official RHEL repository](#install-php-from-official-rhel-repository).
-1. Restart Apache:
-
-```
-$ systemctl restart httpd24-httpd
+systemctl restart httpd24-httpd
 ```
 
 No additional PHP configuration is required.
@@ -211,38 +211,39 @@ EPEL (Extra Packages for Enterprise Linux) is an open source repository which
 
 1. Turn on the EPEL repository and search for PHP:
 
-```
-$ yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-$ yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
-$ yum install yum-utils
-$ subscription-manager repos --enable=rhel-7-server-optional-rpms
-$ yum-config-manager --enable remi-php72
-$ yum update
-$ yum search php72
-```
+    ```
+    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+    yum install yum-utils
+    subscription-manager repos --enable=rhel-7-server-optional-rpms
+    yum-config-manager --enable remi-php72
+    yum update
+    yum search php72
+    ```
 
     All available PHP packages are listed.
-1.  Install PHP:
 
-```
-$ yum install php72 php72-php php72-php-cli php72-php-gd php72-php-json php72-php-mbstring php72-php-mysqlnd php72-php-xml php72-php-zip php72-php-pdo php72-php-intl
-```
+2. Install PHP:
 
-1. After PHP is installed, create a symbolic link:
+    ```
+    yum install php72 php72-php php72-php-cli php72-php-gd php72-php-json php72-php-mbstring php72-php-mysqlnd php72-php-xml php72-php-zip php72-php-pdo php72-php-intl
+    ```
 
-```
-$ ln -sf /opt/remi/php72/root/bin/php /usr/bin/php
-```
+3. After PHP is installed, create a symbolic link:
 
-1. Reopen the terminal if you cannot verify with `php -v` and try again.
-1. Configure Apache. Follow the steps in [Configure existing Apache](#configure-existing-Apache).
-1. Because the location of the PHP `.so` file is different, use the following when setting the PHP module in the Apache configuration:
+    ```
+    ln -sf /opt/remi/php72/root/bin/php /usr/bin/php
+    ```
 
-```
-LoadModule php7_module /opt/remi/php72/root/lib64/httpd/modules/libphp7.so.
-```
+4. Reopen the terminal if you cannot verify with `php -v` and try again.
+5. Configure Apache. Follow the steps in [Configure existing Apache](#configure-existing-Apache).
+6. Because the location of the PHP `.so` file is different, use the following when setting the PHP module in the Apache configuration:
 
-1. Follow the steps in [Upgrade PHP](#upgrade-php) to upgrate your PHP.
+    ```
+    LoadModule php7_module /opt/remi/php72/root/lib64/httpd/modules/libphp7.so.
+    ```
+
+7. Follow the steps in [Upgrade PHP](#upgrade-php) to upgrate your PHP.
 
 ## CentOS – Install dependencies from community repository EPEL with Remi
 
@@ -252,77 +253,77 @@ CentOS also does not offer the latest PHP version in the default repositories. T
 
 1. Install the EPEL repository:
 
-```
-$ yum install epel-release
-```
+    ```
+    yum install epel-release
+    ```
 
-1. Install the Remi repository:
+2. Install the Remi repository:
 
-```
-$ yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
-```
+    ```
+    yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+    ```
 
-1. Install `yum-utils` packages (if not already installed):
+3. Install `yum-utils` packages (if not already installed):
 
-```
-$ yum install yum-utils
-```
+    ```
+    yum install yum-utils
+    ```
 
-1. Enable the Remi repository:
+4. Enable the Remi repository:
 
-```
-$ yum-config-manager --enable remi-php72
-$ yum update
-```
+    ```
+    yum-config-manager --enable remi-php72
+    yum update
+    ```
 
-1. Verify the repository is enabled:
+5. Verify the repository is enabled:
 
-```
-$ yum search php72
-```
+    ```
+    yum search php72
+    ```
 
-1. Install PHP:
+6. Install PHP:
 
-```
-$ yum install php72 php72-php php72-php-cli php72-php-gd php72-php-json php72-php-mbstring php72-php-mysqlnd php72-php-xml php72-php-zip php72-php-pdo php72-php-intl
-```
+    ```
+    yum install php72 php72-php php72-php-cli php72-php-gd php72-php-json php72-php-mbstring php72-php-mysqlnd php72-php-xml php72-php-zip php72-php-pdo php72-php-intl
+    ```
 
-1. Configure Apache.
+7. Configure Apache.
 
-  - Use the steps in [Configure existing Apache (httpd-2.4.\*)](#configure-existing-apache-httpd-2-4) as a reference, but because the location of the PHP `.so` file is different, search for the location of a file similar to `libphp72.so` and use that path when setting the PHP module in the Apache configuration.
+    * Use the steps in [Configure existing Apache (httpd-2.4.\*)](#configure-existing-apache-httpd-2-4) as a reference, but because the location of the PHP `.so` file is different, search for the location of a file similar to `libphp72.so` and use that path when setting the PHP module in the Apache configuration.
 
-  - You do not need to configure Apache if you have already installed it through the package manager.
+    * You do not need to configure Apache if you have already installed it through the package manager.
 
-1. Restart Apache:
+8. Restart Apache:
 
-```
-$ systemctl restart httpd
-```
+    ```
+    systemctl restart httpd
+    ```
 
-1. Verify that the installed version is set:
+9. Verify that the installed version is set:
 
-```
-php -v
-```
+    ```
+    php -v
+    ```
 
-1. If the result is not the newly installed version, modify the PHP symbolic link with the path to the new version:
+10. If the result is not the newly installed version, modify the PHP symbolic link with the path to the new version:
 
-```
-/opt/remi/php72/root/bin/php
-```
+    ```
+    /opt/remi/php72/root/bin/php
+    ```
 
-1. Remove the old version of PHP.
+11. Remove the old version of PHP.
 
 ### Install Apache from community repository EPEL with Remi
 
 1. To install Apache, enter the following command:
 
-```
-$ yum install httpd httpd-tools mod_ssl
-```
+    ```
+    yum install httpd httpd-tools mod_ssl
+    ```
 
-1. To start Apache, enter the following command:
+2. To start Apache, enter the following command:
 
-```
-$ systemctl start httpd
-```
+    ``
+    ystemctl start httpd
+    ``

--- a/content/en/docs/apim_installation/apiportal_install/install_software.md
+++ b/content/en/docs/apim_installation/apiportal_install/install_software.md
@@ -13,29 +13,29 @@ Before you start, check the [Installation prerequisites](/docs/apim_installation
 ## Install API Portal software
 
 1. Download the installation package for your OS from Axway Support at [https://support.axway.com](https://support.axway.com/), and upload it to your host machine.
-1. Log in to the host machine as the `root` user.
-1. Extract the installation package:
+2. Log in to the host machine as the `root` user.
+3. Extract the installation package:
 
     ```
     # tar xpvzf <package_name>.tgz
     ```
 
-1. Run the install script:
+4. Run the install script:
 
     ```
     # sh apiportal_install.sh
     ```
 
-1. Enter the appropriate values when prompted by the installation script. The options you are prompted for include:
-    - Change the default install path. The default path that API Portal is installed in is `/opt/axway/apiportal/htdoc` or you can specify a custom path. The folders specified in the custom path are created if they do not already exist.
-    - Use MySQL in SSL mode (with one way authentication or two way authentication). The certificates generated from MySQL Server must be located in `/etc/mysql/certs/`.
-    - Database connection details. The default port is `3306` or you can specify a different one. The database user is the user you created for API Portal. See [Configure the database server](/docs/apim_installation/apiportal_install/install_software_configure_database/).
-    - Install API Portal in a high availability cluster setup with database replication.
-    - Locations of `php.ini` and `apiportal.conf` configuration files.
-    - Encrypt the Public API mode user password and store the encryption key in a specified directory. The directory is created along with a file. The last segment of the directory is the file name. For example: `/sample/directory/for/encryption/key` creates an empty file named "key" in the desired directory. You can also use a script to encrypt the password later. For more details, see [Encrypt the Public API user password (optional)](/docs/apim_installation/apiportal_install/upgrade_automatic/#encrypt-the-public-api-mode-user-password-optional).
-    - Configure API Portal with SSL/TLS. For HTTPS, you can either provide a certificate and private key, or use a self-signed certificate. For more details, see [Configure API Portal to run with HTTP or HTTPS](#configure-api-portal-to-run-with-http-or-https).
+5. Enter the appropriate values when prompted by the installation script. The options you are prompted for include:
+    * Change the default install path. The default path that API Portal is installed in is `/opt/axway/apiportal/htdoc` or you can specify a custom path. The folders specified in the custom path are created if they do not already exist.
+    * Use MySQL in SSL mode (with one way authentication or two way authentication). The certificates generated from MySQL Server must be located in `/etc/mysql/certs/`.
+    * Database connection details. The default port is `3306` or you can specify a different one. The database user is the user you created for API Portal. See [Configure the database server](/docs/apim_installation/apiportal_install/install_software_configure_database/).
+    * Install API Portal in a high availability cluster setup with database replication.
+    * Locations of `php.ini` and `apiportal.conf` configuration files.
+    * Encrypt the Public API mode user password and store the encryption key in a specified directory. The directory is created along with a file. The last segment of the directory is the file name. For example: `/sample/directory/for/encryption/key` creates an empty file named "key" in the desired directory. You can also use a script to encrypt the password later. For more details, see [Encrypt the Public API user password (optional)](/docs/apim_installation/apiportal_install/upgrade_automatic/#encrypt-the-public-api-mode-user-password-optional).
+    * Configure API Portal with SSL/TLS. For HTTPS, you can either provide a certificate and private key, or use a self-signed certificate. For more details, see [Configure API Portal to run with HTTP or HTTPS](#configure-api-portal-to-run-with-http-or-https).
 
-1. To configure the SE Linux, enter the following commands:
+6. To configure the SE Linux, enter the following commands:
 
     ```
     setsebool -P httpd_read_user_content 1
@@ -68,11 +68,11 @@ If you choose not to configure SSL/TLS, API Portal runs with plain HTTP.
 If you choose to configure SSL/TLS, API Portal runs with HTTPS and you can choose one of the following options:
 
 1. Custom certificate:
-    - The installation prompts you for the path to a certificate and private key.
-    - It checks whether the private key is generated with a passphrase. If it is, the script prompts you for the passphrase and a path to store it. The last segment of the passphrase path is the file name. For example, if you enter `/home/passphrase`, the passphrase is stored in a file with the name `passphrase` in the `/home` directory.
-    - It prompts you for the host name.
-1. API Portal is configured to run with HTTPS using the provided certificate and key.
-1. Self-signed certificate: The installation generates a self-signed certificate and API Portal is configured to run with HTTPS using the self signed certificate.
+    * The installation prompts you for the path to a certificate and private key.
+    * It checks whether the private key is generated with a passphrase. If it is, the script prompts you for the passphrase and a path to store it. The last segment of the passphrase path is the file name. For example, if you enter `/home/passphrase`, the passphrase is stored in a file with the name `passphrase` in the `/home` directory.
+    * It prompts you for the host name.
+2. API Portal is configured to run with HTTPS using the provided certificate and key.
+3. Self-signed certificate: The installation generates a self-signed certificate and API Portal is configured to run with HTTPS using the self signed certificate.
 
 To complete the HTTP/HTTPS configuration, you must restart Apache. The installation script tries to detect the Apache service and prompts you to restart it. If the script cannot detect Apache you must manually restart Apache.
 
@@ -86,12 +86,12 @@ You must also install the EasyBlog and EasyDiscuss components.
 
     If after the installation you experience difficulties with the Joomla! administrator password, you can try to reset the password. For more details, see [How do you recover or reset your admin password?](https://docs.joomla.org/How_do_you_recover_or_reset_your_admin_password%3F)
 
-1. Click **Components > EasyBlog**, and follow the instructions in the EasyBlog installer.
-1. If prompted to select the installation method, select **Installation via Directory**, select the package from the drop-down list, and follow the instructions in the installer to the finish.
+2. Click **Components > EasyBlog**, and follow the instructions in the EasyBlog installer.
+3. If prompted to select the installation method, select **Installation via Directory**, select the package from the drop-down list, and follow the instructions in the installer to the finish.
 
     Do not install any of the modules and plugins unless you plan to use them. To prevent installing any modules, click **Modules** and deselect **Select All**, then repeat the same for **Plugins**.
 
-1. Click **Components > EasyDiscuss**, and repeat the component installation as described for EasyBlog.
+4. Click **Components > EasyDiscuss**, and repeat the component installation as described for EasyBlog.
 
 {{< alert title="Note" color="primary" >}} To resolve a known issue (caused by EasyBlog) with broken menu paths when creating new custom menus for your API Portal in JAI, you must rebuild the menu paths. In JAI, select **Menus > Main Menu** and click **Rebuild**. You only need to rebuild the menu paths once after installation or upgrade. {{< /alert >}}
 
@@ -100,13 +100,13 @@ You must also install the EasyBlog and EasyDiscuss components.
 To uninstall the API Portal software:
 
 1. Log in to the host machine as the `root` user.
-1. Change to the directory containing the API Portal installation package.
-1. Run the uninstall script:
+2. Change to the directory containing the API Portal installation package.
+3. Run the uninstall script:
 
     ```
     # ./apiportal_uninstall.sh
     ```
 
-1. Enter the appropriate values when prompted by the uninstall script.
+4. Enter the appropriate values when prompted by the uninstall script.
 
     When prompted for the MySQL user name, do not use the SSL MySQL user. Use an ordinary MySQL user that requires only a user name and password. The user must have privileges to drop the API Portal database.

--- a/content/en/docs/apim_installation/apiportal_install/install_software_configure_database.md
+++ b/content/en/docs/apim_installation/apiportal_install/install_software_configure_database.md
@@ -14,12 +14,12 @@ Connect to your MySQL or MariaDB database, and configure the database for API P
 
     `bind-address = 127.0.0.1`
 
-1. Set the value for `expire_logs_days`. The default is `0`, no automatic removal.
-1. Set the maximum size of the binary log file in `max_binlog_size`.
-1. Set the maximum number of connections in `max_connections`. The default is `151`.
-1. Set the size of the buffer pool in `innodb_buffer_pool_size`.
-1. Set the size of the log files in a log group in `innodb_log_file_size`.
-1. Set the size of database storage to a minimum of 100 MB. This is the recommended value for the most common environments, which include the use of blog posts, forums, comments, and so on.
+2. Set the value for `expire_logs_days`. The default is `0`, no automatic removal.
+3. Set the maximum size of the binary log file in `max_binlog_size`.
+4. Set the maximum number of connections in `max_connections`. The default is `151`.
+5. Set the size of the buffer pool in `innodb_buffer_pool_size`.
+6. Set the size of the log files in a log group in `innodb_log_file_size`.
+7. Set the size of database storage to a minimum of 100 MB. This is the recommended value for the most common environments, which include the use of blog posts, forums, comments, and so on.
 
 For more details on the variables and how they affect the performance of the database server, see [MySQL Server System Variables](https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html) or [MariaDB Server System Variables](https://mariadb.com/kb/en/mariadb/server-system-variables/).
 
@@ -33,26 +33,23 @@ To generate the SSL-RSA certificates and enable SSL in the MySQL or MariaDB serv
 
 You must first create the database server and the client certificate and key files. During the process, you must respond to several prompts from the Open SSL commands:
 
-- To generate test files, press Enter to all prompts.
-- To generate files for production use, provide actual (non-empty) responses.
+* To generate test files, press Enter to all prompts.
+* To generate files for production use, provide actual (non-empty) responses.
 
 You must enter different domain names for the CA and the client-server certificate.
 
 1. To create the RSA certificates, enter the following commands in the given order, and respond to any prompts you receive:
 
-    `openssl genrsa 2048 > /etc/mysql/certs/ca-key.pem`
+    ```
+    openssl genrsa 2048 > /etc/mysql/certs/ca-key.pem
+    openssl req -new -x509 -nodes -days 3600 -key /etc/mysql/certs/ca-key.pem > /etc/mysql/certs/ca.pem
+    openssl req -newkey rsa:2048 -days 3600 -nodes -keyout /etc/mysql/certs/server-key.pem > /etc/mysql/certs/server-req.pem
+    openssl x509 -req -in /etc/mysql/certs/server-req.pem -days 3600 -CA /etc/mysql/certs/ca.pem -CAkey /etc/mysql/certs/ca-key.pem -set_serial 01 > server-cert.pem
+    openssl req -newkey rsa:2048 -days 3600 -nodes -keyout client-key.pem > client-req.pem
+    openssl x509 -req -in client-req.pem -days 3600 -CA /etc/mysql/certs/ca-cert.pem -CAkey /etc/mysql/certs/ca-key.pem -set_serial 01 > client-cert.pem
+    ```
 
-    `openssl req -new -x509 -nodes -days 3600 -key /etc/mysql/certs/ca-key.pem > /etc/mysql/certs/ca.pem`
-
-    `openssl req -newkey rsa:2048 -days 3600 -nodes -keyout /etc/mysql/certs/server-key.pem > /etc/mysql/certs/server-req.pem`
-
-    `openssl x509 -req -in /etc/mysql/certs/server-req.pem -days 3600 -CA /etc/mysql/certs/ca.pem -CAkey /etc/mysql/certs/ca-key.pem -set_serial 01 > server-cert.pem`
-
-    `openssl req -newkey rsa:2048 -days 3600 -nodes -keyout client-key.pem > client-req.pem`
-
-    `openssl x509 -req -in client-req.pem -days 3600 -CA /etc/mysql/certs/ca-cert.pem -CAkey /etc/mysql/certs/ca-key.pem -set_serial 01 > client-cert.pem`
-
-1. To verify the generated certificate, enter the following command:
+2. To verify the generated certificate, enter the following command:
 
     `openssl verify -CAfile ca.pem server-cert.pem client-cert.pem`
 
@@ -61,25 +58,23 @@ You must enter different domain names for the CA and the client-server certifica
 To enable secure connection in the MySQL or MariaDB server-side configuration, do the following:
 
 1. To start the database server so that it permits clients to connect securely, use options that identify the certificate and key files the server uses when establishing a secure connection:
-    - `--ssl-ca` identifies the Certificate Authority (CA) certificate.
-    - `--ssl-cert` identifies the server public key certificate. This can be sent to the client and authenticated against the CA certificate the client has.
-    - `--ssl-key` identifies the server private key.
+    * `--ssl-ca` identifies the Certificate Authority (CA) certificate.
+    * `--ssl-cert` identifies the server public key certificate. This can be sent to the client and authenticated against the CA certificate the client has.
+    * `--ssl-key` identifies the server private key.
 
-1. Edit the `/etc/my.cnf` file as follows to configure the certificates:
+2. Edit the `/etc/my.cnf` file as follows to configure the certificates:
 
-    `[mysqld]`
-
-    `...`
-
-    `ssl-ca=/<path>/ca.pem`
-
-    `ssl-cert=/<path>/server-cert.pem`
-
-    `ssl-key=/<path>/server-key.pem`
+    ```
+    [mysqld]
+    ...
+    ssl-ca=/<path>/ca.pem
+    ssl-cert=/<path>/server-cert.pem
+    ssl-key=/<path>/server-key.pem
+    ```
 
     Replace the `<path>` placeholders with the path to your certificates.
 
-1. Save the file and restart the database:
+3. Save the file and restart the database:
 
     `service mysqld restart`
 
@@ -91,7 +86,7 @@ After configuring the MySQL or MariaDB database server with certificates, you ne
 
     `MySQL -u root –p <password>`
 
-1. Enter the following command:
+2. Enter the following command:
 
     `show variables like '%ssl%';`
 
@@ -113,26 +108,25 @@ In addition, for API Portal to be able to connect to the MySQL or MariaDB datab
 
 You must configure a strong password for this user account or the API Portal installation will not succeed. The password requirements are:
 
-- At least 10 characters long
-- Contains at least one digit
-- Contains at least one uppercase letter
-- Contains at least one lowercase letter
-- Contains at least one special character `!@#$%^&*`
+* At least 10 characters long
+* Contains at least one digit
+* Contains at least one uppercase letter
+* Contains at least one lowercase letter
+* Contains at least one special character `!@#$%^&*`
 
 ### Configure a user account without authentication
 
 If you do not want to use a secure connection, you can configure API Portal to use a user account without authentication.
 
 1. Connect to your database server.
-1. To configure a user account, enter the following:
+2. To configure a user account, enter the following:
 
-    `CREATE USER '<user name>'@'<your API Portal host IP address>' IDENTIFIED BY '<your password>';`
-
-    `GRANT ALL PRIVILEGES ON <database name>.* TO '<user name>'@'<your API Portal host>' IDENTIFIED BY '<your password>' WITH GRANT OPTION;`
-
-    `GRANT ALL PRIVILEGES ON <database name>.* TO '<user name>'@'<your API Portal host>' IDENTIFIED BY '<your password>' WITH GRANT OPTION;`
-
-    `FLUSH PRIVILEGES;`
+    ```
+    CREATE USER '<user name>'@'<your API Portal host IP address>' IDENTIFIED BY '<your password>';
+    GRANT ALL PRIVILEGES ON <database name>.* TO '<user name>'@'<your API Portal host>' IDENTIFIED BY '<your password>' WITH GRANT OPTION;
+    GRANT ALL PRIVILEGES ON <database name>.* TO '<user name>'@'<your API Portal host>' IDENTIFIED BY '<your password>' WITH GRANT OPTION;
+    FLUSH PRIVILEGES;
+    ```
 
     Replace the placeholders with the actual values.
 
@@ -140,8 +134,8 @@ If you do not want to use a secure connection, you can configure API Portal to 
 
 MariaDB and MySQL 5.7 support one-way and two-way authentication modes. Authentication modes are handled based on the User Grant.
 
-- **One-way (Server CA) authentication**: One-way authentication mode expects the client to provide a CA file generated in database server.
-- **Two-way (mutual) authentication**: Two-way authentication mode expects the client to provide both the CA and the client certificates generated in database server.
+* **One-way (Server CA) authentication**: One-way authentication mode expects the client to provide a CA file generated in database server.
+* **Two-way (mutual) authentication**: Two-way authentication mode expects the client to provide both the CA and the client certificates generated in database server.
 
 #### Configure one-way authentication
 
@@ -149,16 +143,16 @@ To enable one-way authentication, create a user with the option `REQUIRE SSL`.
 
 1. Log in to the database server as the `root` user and enter the following:
 
-    `CREATE USER '<user name>'@’%’ IDENTIFIED BY '<password>' REQUIRE SSL;`
-
-    `GRANT ALL PRIVILEGES ON *.* TO '<user name>'@'%' WITH GRANT OPTION;`
-
-    `FLUSH PRIVILEGES;`
+    ```
+    CREATE USER '<user name>'@’%’ IDENTIFIED BY '<password>' REQUIRE SSL;
+    GRANT ALL PRIVILEGES ON *.* TO '<user name>'@'%' WITH GRANT OPTION;
+    FLUSH PRIVILEGES;
+    ```
 
     Replace the placeholders with the user name and password you want to use.
 
-1. Copy the `ca.pem` CA certificate to a folder (for example, `/etc/mysql/certs/`) on the machine where you installed API Portal.
-1. To test the connection between the database client and server, enter the following:
+2. Copy the `ca.pem` CA certificate to a folder (for example, `/etc/mysql/certs/`) on the machine where you installed API Portal.
+3. To test the connection between the database client and server, enter the following:
 
     `MySQL --ssl-ca=/etc/mysql/certs/ca.pem -h xxx.xxx.xxx.xxx --port="3306" -u <user name> --password="<password>"`
 
@@ -168,19 +162,19 @@ To enable two-way authentication, create a user with the option `REQUIRE X509`.
 
 1. Log in to the database server as the `root` user and enter the following:
 
-    `CREATE USER '<user name>'@’%’ IDENTIFIED BY '<password>' REQUIRE X509L;`
-
-    `GRANT ALL PRIVILEGES ON *.* TO '<user name>'@'%' WITH GRANT OPTION;`
-
-    `FLUSH PRIVILEGES;`
+    ```
+    CREATE USER '<user name>'@’%’ IDENTIFIED BY '<password>' REQUIRE X509L;
+    GRANT ALL PRIVILEGES ON *.* TO '<user name>'@'%' WITH GRANT OPTION;
+    FLUSH PRIVILEGES;
+    ```
 
     Replace the placeholders with the user name and password you want to use.
 
-1. Copy the following client certificates to a folder (for example, `/etc/mysql/certs/`) on the machine where you installed API Portal:
-    - `client-key.pem`
-    - `client-cert.pem`
-    - `ca.pem`
+2. Copy the following client certificates to a folder (for example, `/etc/mysql/certs/`) on the machine where you installed API Portal:
+    * `client-key.pem`
+    * `client-cert.pem`
+    * `ca.pem`
 
-1. To test the connection between the database client and server, enter the following:
+3. To test the connection between the database client and server, enter the following:
 
     `MySQL --ssl-ca=/etc/mysql/certs/ca.pem --ssl-cert=/etc/mysql/certs/client-cert.pem --ssl-key=/etc/mysql/certs/client-key.pem -h xxx.xxx.xxx.xxx --port="3306" -u <user name> --password="<password>"`

--- a/content/en/docs/apim_installation/apiportal_install/install_software_prereqs.md
+++ b/content/en/docs/apim_installation/apiportal_install/install_software_prereqs.md
@@ -14,9 +14,9 @@ Installing API Portal dependencies requires an Internet connection. Offline ins
 
 The minimum hardware requirements are:
 
-- 2 Ghz Dual Core Intel Core or AMD Opteron or faster
-- 8 GB RAM
-- 40 GB free disk space
+* 2 Ghz Dual Core Intel Core or AMD Opteron or faster
+* 8 GB RAM
+* 40 GB free disk space
 
 ## Software requirements
 
@@ -30,23 +30,23 @@ You must have Red Hat Enterprise Linux (RHEL) 7 or CentOS 7 installed.
 
 You must have one of the following installed:
 
-- MySQL 5.6 or later
+* MySQL 5.6 or later
 
     {{< alert title="Note" color="primary" >}}API Portal does not officially support MySQL 8 as Joomla! does not support it. However, API Portal has been tested to work with MySQL 8 using a workaround. You must apply the workaround described at [Joomla! and MySQL 8](https://docs.joomla.org/Joomla_and_MySQL_8) before you install API Portal.{{< /alert >}}
 
-- MariaDB 5.5.50 or later
+* MariaDB 5.5.50 or later
 
 For details how to install a database using `yum`, see the following:
 
-- [My SQL installation instructions](http://dev.mysql.com/doc/refman/5.6/en/linux-installation-yum-repo.html)
-- [MariaDB installation instructions](https://mariadb.com/kb/en/mariadb/yum/)
+* [My SQL installation instructions](http://dev.mysql.com/doc/refman/5.6/en/linux-installation-yum-repo.html)
+* [MariaDB installation instructions](https://mariadb.com/kb/en/mariadb/yum/)
 
 If your database is on a remote host, you must configure a MySQL client or a MariaDB client.
 
 For more details, see following product documentation:
 
-- [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/)
-- [MariaDB documentation](https://mariadb.com/kb/en/mariadb/documentation/)
+* [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/)
+* [MariaDB documentation](https://mariadb.com/kb/en/mariadb/documentation/)
 
 ### PHP
 
@@ -54,18 +54,18 @@ API Portal requires PHP 7.1 or later.
 
 In addition you must have the following PHP modules installed:
 
-- `php-zip`
-- `php-openssl`
-- `mod_php`
-- `php-common`
-- `php-mysqld` or `php-mysqli`
-- `php-cli`
-- `php-gd`
-- `php-intl`
-- `php-mbstring`
-- `php-pdo`
-- `php-xml`
-- `php-json`
+* `php-zip`
+* `php-openssl`
+* `mod_php`
+* `php-common`
+* `php-mysqld` or `php-mysqli`
+* `php-cli`
+* `php-gd`
+* `php-intl`
+* `php-mbstring`
+* `php-pdo`
+* `php-xml`
+* `php-json`
 
 #### Install dependencies
 
@@ -75,10 +75,10 @@ For more information on installing dependencies, see [Install API Portal depende
 
 API Portal requires the following to be installed:
 
-- API Gateway 7.8
-- API Manager 7.8
-- Apache 2.4 or later
-- OpenSSL
+* API Gateway 7.8
+* API Manager 7.8
+* Apache 2.4 or later
+* OpenSSL
 
 {{< alert title="Note" color="primary" >}}The monitoring feature of API Portal, which enables your API consumers to monitor application and API usage, requires a connected API Manager with monitoring metrics enabled. {{< /alert >}}
 
@@ -90,58 +90,58 @@ If you are installing API Portal on an air-gapped server, or your environment o
 
 ### Dependencies with Apache
 
-- rhel-apache-conf
-- libXpm
-- libtool-ltdl
-- mod_ssl
-- t1lib
+* rhel-apache-conf
+* libXpm
+* libtool-ltdl
+* mod_ssl
+* t1lib
 
 ### Dependencies with MySQL
 
-- mysql-community-libs
-- mysql-community-libs-compat
-- mysql-community-server
-- mysql-community-client
-- mysql-community-common
-- perl
-- perl-Carp
-- perl-Encode
-- perl-Exporter
-- perl-File-Path
-- perl-File-Temp
-- perl-Filter
-- perl-Getopt-Long
-- perl-HTTP-Tiny
-- perl-PathTools
-- perl-Pod-Escapes
-- perl-Pod-Perldoc
-- perl-Pod-Simple
-- perl-Pod-Usage
-- perl-Scalar-List-Utils
-- perl-Socket
-- perl-Storable
-- perl-Text-ParseWords
-- perl-Time-HiRes
-- perl-Time-Local
-- perl-constant
-- perl-libs
-- perl-macros
-- perl-parent
-- perl-podlators
-- perl-threads
-- perl-threads-shared
+* mysql-community-libs
+* mysql-community-libs-compat
+* mysql-community-server
+* mysql-community-client
+* mysql-community-common
+* perl
+* perl-Carp
+* perl-Encode
+* perl-Exporter
+* perl-File-Path
+* perl-File-Temp
+* perl-Filter
+* perl-Getopt-Long
+* perl-HTTP-Tiny
+* perl-PathTools
+* perl-Pod-Escapes
+* perl-Pod-Perldoc
+* perl-Pod-Simple
+* perl-Pod-Usage
+* perl-Scalar-List-Utils
+* perl-Socket
+* perl-Storable
+* perl-Text-ParseWords
+* perl-Time-HiRes
+* perl-Time-Local
+* perl-constant
+* perl-libs
+* perl-macros
+* perl-parent
+* perl-podlators
+* perl-threads
+* perl-threads-shared
 
 ### Dependencies with PHP
 
-- php
-- php-mbstring
-- php-opcache
-- apr
-- apr-util
-- httpd
-- httpd-tools
-- mailcap
-- php-cli
-- php-common
-- openssl
-- openssl-libs
+* php
+* php-mbstring
+* php-opcache
+* apr
+* apr-util
+* httpd
+* httpd-tools
+* mailcap
+* php-cli
+* php-common
+* openssl
+* openssl-libs

--- a/content/en/docs/apim_installation/apiportal_install/install_software_redis.md
+++ b/content/en/docs/apim_installation/apiportal_install/install_software_redis.md
@@ -15,31 +15,31 @@ Before installing Redis, you must install `phpize` that prepares your environmen
 1. `phpize` is installed as part of the PHP development package (for example, `php5.6-dev` or `php7.0-dev`). If you do not have a PHP development package installed, install the correct package for your PHP version:
 
     ```
-    $ yum install php-devel
+    yum install php-devel
     ```
 
-1. Download the latest available version of `phpredis` from the [Github repository](https://github.com/phpredis/phpredis), and extract the package. For example:
+2. Download the latest available version of `phpredis` from the [Github repository](https://github.com/phpredis/phpredis), and extract the package. For example:
 
     ```
-    $ wget https://github.com/phpredis/phpredis/archive/3.1.4.zip
-    $ unzip phpredis-3.1.4.zip
+    wget https://github.com/phpredis/phpredis/archive/3.1.4.zip
+    unzip phpredis-3.1.4.zip
     ```
 
-1. Change to the directory where you extracted the `phpredis` package, and run the following:
+3. Change to the directory where you extracted the `phpredis` package, and run the following:
 
     ```
-    $ phpize
-    $ ./configure
-    $ make && make install
+    phpize
+    ./configure
+    make && make install
     ```
 
-1. You must enable the `phpredis` extension. To do so, you can either edit the `php.ini` file, or add a `redis.ini` file in the folder that PHP uses to load additional modules from. By default, this folder is one of the following:
+4. You must enable the `phpredis` extension. To do so, you can either edit the `php.ini` file, or add a `redis.ini` file in the folder that PHP uses to load additional modules from. By default, this folder is one of the following:
 
-    - `/etc/php5/conf.d` if you have a PHP 5.x installation.
-    - `/etc/php7/conf.d` if you have a PHP 7.x installation.
-    - `/etc/php/conf.d` if you have installed PHP from the official repository.
+    * `/etc/php5/conf.d` if you have a PHP 5.x installation.
+    * `/etc/php7/conf.d` if you have a PHP 7.x installation.
+    * `/etc/php/conf.d` if you have installed PHP from the official repository.
 
-1. The `redis.ini` file should have the following contents:
+5. The `redis.ini` file should have the following contents:
 
     ```
     extension=redis.so
@@ -52,19 +52,19 @@ To install Redis, follow these steps:
 1. Download the Redis package:
 
     ```
-    $ wget http://download.redis.io/redis-stable.tar.gz
+    wget http://download.redis.io/redis-stable.tar.gz
     ```
 
-1. Extract the package:
+2. Extract the package:
 
     ```
-    $ tar xvzf redis-stable.tar.gz
+    tar xvzf redis-stable.tar.gz
     ```
 
-1. Change to the directory where you extracted the package and run the following:
+3. Change to the directory where you extracted the package and run the following:
 
     ```
-    $ make && make install
+    make && make install
     ```
 
 ## Configure Redis
@@ -75,14 +75,14 @@ However, if you have installed Redis on a different host machine, or configured 
 
 1. Open the following configuration file for editing: `/opt/axway/apiportal/htdoc/configuration.php`
 
-1. Locate the following lines:
+2. Locate the following lines:
 
     ```
     redis_server_host = 'localhost';
     redis_server_port = '6379';
     ```
 
-1. Change the values for the Redis host and port as required and save the file.
+3. Change the values for the Redis host and port as required and save the file.
 
 ## Verify Redis installation
 
@@ -91,21 +91,21 @@ For information on how to start the Redis server, check that Redis is working co
 To verify that Redis is running, enter one of the following commands:
 
 ```
-$ netstat -tupan | grep <REDIS_PORT>
+netstat -tupan | grep <REDIS_PORT>
 ```
 
 ```
-$ ps aux | grep redis
+ps aux | grep redis
 ```
 
 ```
-$ redis-cli ping
+redis-cli ping
 ```
 
 To verify that Redis is being used by API Portal, refresh the API Catalog page and enter the following command:
 
 ```
-$ redis-cli keys *_apicatalog
+redis-cli keys *_apicatalog
 ```
 
 ## Configure Redis cache settings in API Portal after installation
@@ -115,4 +115,5 @@ To change how long data is preserved in the cache:
 1. In the JAI, click **Components > API Portal > Additional Settings**.
 2. In **Cache Timeout**, enter how long (in seconds) APIs are preserved in the cache.
 3. Click **Save**.
+
 Use the **Purge cache** button to clear the cache at any time.

--- a/content/en/docs/apiportal_ha/HA_datastorage.md
+++ b/content/en/docs/apiportal_ha/HA_datastorage.md
@@ -4,36 +4,122 @@
     "weight":"3",
     "date":"2019-08-09",
     "description":"Understand where API Portal stores API Management data."
-} 
+}
 
 ## Data storage
 
 API Portal stores API Management data both in relational database management system (RDBMS) and as files on disk. The stored data includes, for example, configuration data and logs, all API Portal customizations, as well as articles and their related data posted in Joomla!, blog, or discussion forum.
 
-The following table describes where API Portal stores data. In RDBMS, `#_` stands for the table prefix of the DB schema. The default `INSTALL_DIR` is `/opt/axway/apiportal/htdoc`.
+The following describes where API Portal stores data. In RDBMS, `#_` stands for the table prefix of the DB schema. The default `INSTALL_DIR` is `/opt/axway/apiportal/htdoc`.
 
-|Data type|Storage location|
-|---------|----------------|
-|**System**|   |
-|API Manager settings (for example, IP address, certificates)|<ul><li>RDBMS: `#_apiportal_configuration`</li><li>Files on disk: `INSTALL_DIR/administrator/components/com_apiportal/assets/cert`</li></ul>|
-|Logs|Files on disk:<ul><li>Software installation: `/var/log/httpd/error_log`</li><li>`INSTALL_DIR/logs`</li></ul>|
-|Public API mode key file|Files on disk: The custom path you specified for the encryption key at install time|
-|**Customization**|   |
-|Theme Magic customizations|Files on disk: `INSTALL_DIR/templates/purity_iii`|
-|Stylesheets (CSS and LESS)|Files on disk: `INSTALL_DIR/templates/purity_iii/`|
-|Company logo|RDBMS: `#_menu`<br>Files on disk: `INSTALL_DIR/components/com_apiportal/assets/img/menu/`|
-|Menu entries and order|RDBMS:<ul><li>`#_menu`</li><li>`#_menu_types`</li></ul>|
-|Changes in the PHP code|Files on disk: `INSTALL_DIR/components/com_apiportal/views/`|
-|ReCaptcha plug-in|RDBMS: `#_extensions`|
-|**Localization**|   |
-|Installed languages|RDBMS: `#_extensions`<br>Files on disk:<ul><li>`INSTALL_DIR/language`</li><li>`INSTALL_DIR/administrator/language`</li><li>`INSTALL_DIR/administrator/manifests/packages`</li></ul>|
-|Language content|RDBMS:<ul><li>`#_menu`</li><li>`#_content`</li><li>`#_categories`</li></ul>|
-|**Articles and posts**|   |
-|Joomla! articles|RDBMS:<ul><li>`#_content`</li><li>`#_content_frontpage`</li><li>`#_content_rating`</li>`#_content_types`<li>`#_content_item_tag_map`</li></ul>|
-|Attachments uploaded to Joomla! content|Files on disk: `INSTALL_DIR/images`|
-|Joomla! categories|RDBMS: `#_categories`|
-|EasyBlog and EasyDiscuss settings and posts|RDBMS:<br>Settings and Posts<ul><li>`#_easyblog_configs`</li><li>`#_discuss_configs`</li></ul>|
-|EasyBlog and EasyDiscuss attachments|RDBMS:<br><ul><li>`#_easyblog_configs`</li><li>`#_discuss_configs`</li></ul><br>Files on disk:<ul><li>`INSTALL_DIR/images/easyblog_*`</li><li>`INSTALL_DIR/media/com_easydiscuss`|
+### System
+
+1. API Manager settings (For example, IP address, certificates.)
+
+    * Files on disk
+        * `INSTALL_DIR/administrator/components/com_apiportal/assets/cert`
+    * RDBMS
+        * `#_apiportal_configuration`
+
+2. Logs
+
+    * Files on disk
+        * `INSTALL_DIR/logs`
+        * (Software installation) `/var/log/httpd/error_log`
+
+3. Public API mode key file
+
+    * Files on disk
+        * The custom path you specified for the encryption key at install time.
+
+### Customization
+
+1. Theme Magic customizations
+
+    * Files on disk
+        * `INSTALL_DIR/templates/purity_iii`
+
+2. Stylesheets (CSS and LESS)
+
+    * Files on disk
+        * `INSTALL_DIR/templates/purity_iii/`
+
+3. Company logo
+
+    * Files on disk
+        * `INSTALL_DIR/components/com_apiportal/assets/img/menu/`
+    * RDBMS
+        * `#_menu`
+
+4. Menu entries and order
+
+    * RDBMS
+        * `#_menu`
+        * `#_menu_types`
+
+5. Changes in the PHP code
+
+    * Files on disk
+        * `INSTALL_DIR/components/com_apiportal/views/`
+
+6. ReCaptcha plug-in
+
+    * RDBMS
+        * `#_extensions`
+
+### Localization
+
+1. Installed languages
+
+    * Files on disk
+        * `INSTALL_DIR/language`
+        * `INSTALL_DIR/administrator/language`
+        * `INSTALL_DIR/administrator/manifests/packages`
+    * RDBMS
+        * `#_extensions`
+
+2. Language content
+
+    * RDBMS
+        * `#_menu`
+        * `#_content`
+        * `#_categories`
+
+### Articles and posts
+
+1. Joomla! articles
+
+    * RDBMS
+        * `#_content`
+        * `#_content_frontpage`
+        * `#_content_rating`
+        * `#_content_types`
+        * `#_content_item_tag_map`
+
+2. Attachments uploaded to Joomla! content
+
+    * Files on disk
+        * `INSTALL_DIR/images`
+
+3. Joomla! categories
+
+    * RDBMS
+        * `#_categories`
+
+4. EasyBlog and EasyDiscuss settings and posts
+
+    * RDBMS: Settings and Posts
+        * `#_easyblog_configs`
+        * `#_discuss_configs`
+
+5. EasyBlog and EasyDiscuss attachments
+
+    * Files on disk
+        * `INSTALL_DIR/images/easyblog_*`
+        * `INSTALL_DIR/media/com_easydiscuss`
+    * RDBMS
+        * `#_easyblog_configs`
+        * `#_discuss_configs`
 
 ### Recommended API Portal data replication
 
@@ -41,8 +127,8 @@ API Portal data between API Portal instances or datacenters is replicated eith
 
 Data can be replicated automatically using the following:
 
-- **RDBMS cluster**: The configured database cluster replicates data between all database nodes in the cluster. For a technical example, see this article about [database cluster setup](https://support.axway.com/en/articles/article-details/id/180417) on Axway Support.
-- **Shared file system solution**: A shared storage solution, like a cluster or shared network file system, synchronizes data across all instances. For a technical example, see this article about [shared file system](https://support.axway.com/en/articles/article-details/id/180405) on Axway Support.
+* **RDBMS cluster**: The configured database cluster replicates data between all database nodes in the cluster. For a technical example, see this article about [database cluster setup](https://support.axway.com/en/articles/article-details/id/180417) on Axway Support.
+* **Shared file system solution**: A shared storage solution, like a cluster or shared network file system, synchronizes data across all instances. For a technical example, see this article about [shared file system](https://support.axway.com/en/articles/article-details/id/180405) on Axway Support.
 
 In the manual, or static data replication, you must use a promotion tool to promote data from one API Portal instance to another. For details, see this article about the [promotion tool](https://support.axway.com/en/articles/article-details/id/180277) on Axway Support.
 

--- a/content/en/docs/apiportal_ha/HA_multi_datacenter.md
+++ b/content/en/docs/apiportal_ha/HA_multi_datacenter.md
@@ -18,15 +18,15 @@ You must configure a relational database management system (RDBMS) to store API�
 
 The database cluster has the following requirements in a multi-datacenter production environment:
 
-- The database must be supported by API Portal. For more information on supported databases, see [Software requirements](/docs/apim_installation/apiportal_install/install_software_prereqs/#software-requirements).
-- For high availability (HA), it is best to have at least three database nodes in each datacenter (for example, to prevent data corruption due to split-brain syndrome). Install the database on each node.
-- Choose a unique name for the database cluster.
-- Do not start any of the databases until the database cluster is fully configured.
-- You must synchronize time on all servers.
-- Renaming a datacenter is not possible, so choose names carefully, and determine a naming convention for each datacenter and rack. For example:
-  - DC1, DC2
-  - RACK1, RACK2, RACK3
-- To avoid firewall issues, you must open the RDBMS ports needed to allow bidirectional communication among the database nodes.
+* The database must be supported by API Portal. For more information on supported databases, see [Software requirements](/docs/apim_installation/apiportal_install/install_software_prereqs/#software-requirements).
+* For high availability (HA), it is best to have at least three database nodes in each datacenter (for example, to prevent data corruption due to split-brain syndrome). Install the database on each node.
+* Choose a unique name for the database cluster.
+* Do not start any of the databases until the database cluster is fully configured.
+* You must synchronize time on all servers.
+* Renaming a datacenter is not possible, so choose names carefully, and determine a naming convention for each datacenter and rack. For example:
+    * DC1, DC2
+    * RACK1, RACK2, RACK3
+* To avoid firewall issues, you must open the RDBMS ports needed to allow bidirectional communication among the database nodes.
 
 For more details on installing and configuring your database, see [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/) or [MariaDB documentation](https://mariadb.com/kb/en/mariadb/documentation/).
 
@@ -44,19 +44,19 @@ For HA, install API Portal on the first node, and then install it on each of th
 
 1. Install API Portal on the first node as detailed in [Install API Portal as software installation](/docs/apim_installation/apiportal_install/install_software/#install-api-portal-software).
 
-    - When prompted for database connection settings during the API Portal software installation, enter the access host of the database you created for this node.
-    - When asked if this is going to be HA setup with database replication, enter `y`.
+    * When prompted for database connection settings during the API Portal software installation, enter the access host of the database you created for this node.
+    * When asked if this is going to be HA setup with database replication, enter `y`.
 
-1. Install the EasyBlog and EasyDiscuss components on the first node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
+2. Install the EasyBlog and EasyDiscuss components on the first node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
 
-{{< alert title="Note" color="primary" >}}When you change the Joomla! admininstrator password on the first node, the password is changed for all nodes. {{< /alert >}}
+    {{< alert title="Note" color="primary" >}}When you change the Joomla! admininstrator password on the first node, the password is changed for all nodes. {{< /alert >}}
 
-1. Install API Portal on each of the other nodes as detailed in [Install API Portal as software installation](/docs/apim_installation/apiportal_install/install_software/#install-api-portal-software). For each node:
+3. Install API Portal on each of the other nodes as detailed in [Install API Portal as software installation](/docs/apim_installation/apiportal_install/install_software/#install-api-portal-software). For each node:
 
-    - When prompted for database connection settings, use the same database server or cluster you used for the first API Portal instance.
-    - The installation checks the database connection and if it is successful for any node other than the first node, it asks you to confirm that this is a HA setup. Enter `y`.
+    * When prompted for database connection settings, use the same database server or cluster you used for the first API Portal instance.
+    * The installation checks the database connection and if it is successful for any node other than the first node, it asks you to confirm that this is a HA setup. Enter `y`.
 
-1. Install the EasyBlog and EasyDiscuss components on each other node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
+4. Install the EasyBlog and EasyDiscuss components on each other node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
 
 #### Upgrade API Portal for HA in multiple datacenters as a software installation
 
@@ -80,9 +80,9 @@ In this scenario, one of the API Portal instances in a datacenter goes down:
 
 The following applies on this scenario:
 
-- The API Portal instance that is down can no longer handle requests.
-- All requests are handled by the remaining API Portal instances in the datacenter.
-- You must restart the API Portal instance that is down.
+* The API Portal instance that is down can no longer handle requests.
+* All requests are handled by the remaining API Portal instances in the datacenter.
+* You must restart the API Portal instance that is down.
 
 ### One database node is down
 
@@ -92,8 +92,8 @@ In this scenario, one database node in a database cluster goes down:
 
 The following applies in this scenario:
 
-- The database cluster tolerates the loss of a node in the cluster, and ensures 100% data consistency when the database cluster is configured for multiple datacenters.
-- You must restart the database node that is down, and connect it to the cluster to synchronize and start operation.
+* The database cluster tolerates the loss of a node in the cluster, and ensures 100% data consistency when the database cluster is configured for multiple datacenters.
+* You must restart the database node that is down, and connect it to the cluster to synchronize and start operation.
 
 {{< alert title="Note" color="primary" >}}When a database node has been down and absent from a cluster for a time, you must repair the node after re-integrating it into the cluster. By design, the database node eventually becomes consistent with the other nodes. {{< /alert >}}
 
@@ -105,10 +105,10 @@ In this scenario, a full datacenter goes down:
 
 The following applies in this scenario:
 
-- The datacenter that is down can no longer handle requests.
-- Load balancer automaticalle routes all requests to the remaining datacenters.
-- API Portal quotas remain the same but over less servers.
-- Do not deploy more data to the remaining API Portal instances until the system is back to normal.
+* The datacenter that is down can no longer handle requests.
+* Load balancer automaticalle routes all requests to the remaining datacenters.
+* API Portal quotas remain the same but over less servers.
+* Do not deploy more data to the remaining API Portal instances until the system is back to normal.
 
 #### Restart the datacenter
 
@@ -126,6 +126,6 @@ In this case, the network between DC 1 and DC 2 is down, while both datacenters 
 
 The following applies in this scenario:
 
-- Datacenters are still operating independently.
-- The data in the database clusters or in the shared file system is not synchronized between the datacenters until the network recovers. Do not deploy any updates to data.
-- When the network recovers, all data is resynchronized automatically.
+* Datacenters are still operating independently.
+* The data in the database clusters or in the shared file system is not synchronized between the datacenters until the network recovers. Do not deploy any updates to data.
+* When the network recovers, all data is resynchronized automatically.

--- a/content/en/docs/apiportal_ha/HA_single_datacenter.md
+++ b/content/en/docs/apiportal_ha/HA_single_datacenter.md
@@ -18,12 +18,12 @@ You must install and configure the database on each database node before install
 
 The database cluster has the following requirements in a production environment:
 
-- The database must be supported by API Portal. For more information on supported databases, see [Software requirements](/docs/apim_installation/apiportal_install/install_software_prereqs/#software-requirements).
-- For HA, it is best to have at least three database nodes in each datacenter (for example, to prevent data corruption due to split-brain syndrome). Install the database on each node.
-- Choose a unique name for the database cluster.
-- Do not start any of the databases until the database cluster is fully configured.
-- You must synchronize time on all servers.
-- To avoid firewall issues, you must open the RDBMS ports needed to allow bidirectional communication among the database nodes.
+* The database must be supported by API Portal. For more information on supported databases, see [Software requirements](/docs/apim_installation/apiportal_install/install_software_prereqs/#software-requirements).
+* For HA, it is best to have at least three database nodes in each datacenter (for example, to prevent data corruption due to split-brain syndrome). Install the database on each node.
+* Choose a unique name for the database cluster.
+* Do not start any of the databases until the database cluster is fully configured.
+* You must synchronize time on all servers.
+* To avoid firewall issues, you must open the RDBMS ports needed to allow bidirectional communication among the database nodes.
 
 For more details on installing and configuring your database, see [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/) or [MariaDB documentation](https://mariadb.com/kb/en/mariadb/documentation/).
 
@@ -31,9 +31,9 @@ For more details on installing and configuring your database, see [MySQL documen
 
 You can use advanced settings to fine-tune the database and its performance:
 
-- To automatically set increment IDs in the database and synchronize the IDs between the API Portal instances, check the settings for `auto_increment_increment` and `auto_increment_offset`.
-- To avoid timeout issues, check the `master-connect-retry` setting.
-- To avoid filling disk space with database replication logs, adjust the `expire_log_days` and `max_binlog_size` as needed.
+* To automatically set increment IDs in the database and synchronize the IDs between the API Portal instances, check the settings for `auto_increment_increment` and `auto_increment_offset`.
+* To avoid timeout issues, check the `master-connect-retry` setting.
+* To avoid filling disk space with database replication logs, adjust the `expire_log_days` and `max_binlog_size` as needed.
 
 For more details on the database settings, see [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/) or [MariaDB documentation](https://mariadb.com/kb/en/mariadb/documentation/).
 
@@ -51,19 +51,19 @@ For HA, install API Portal on the first node, and then install it on each of th
 
 1. Install API Portal on the first node as detailed in [Install API Portal as software installation](/docs/apim_installation/apiportal_install/install_software/#install-api-portal-software).
 
-    - When prompted for database connection settings during the API Portal software installation, enter the access host of the database you created for this node.
-    - When asked if this is going to be HA setup with database replication, enter `y`.
+    * When prompted for database connection settings during the API Portal software installation, enter the access host of the database you created for this node.
+    * When asked if this is going to be HA setup with database replication, enter `y`.
 
-1. Install the EasyBlog and EasyDiscuss components on the first node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
+2. Install the EasyBlog and EasyDiscuss components on the first node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
 
     {{< alert title="Note" color="primary" >}}When you change the Joomla! admininstrator password on the first node, the password is changed for all nodes. {{< /alert >}}
 
-1. Install API Portal on each of the other nodes as detailed in [Install API Portal as software installation](/docs/apim_installation/apiportal_install/install_software/#install-api-portal-software). For each node:
+3. Install API Portal on each of the other nodes as detailed in [Install API Portal as software installation](/docs/apim_installation/apiportal_install/install_software/#install-api-portal-software). For each node:
 
-    - When prompted for database connection settings, use the same database server or cluster you used for the first API Portal instance.
-    - The installation checks the database connection and if it is successful for any node other than the first node, it asks you to confirm that this is a HA setup. Enter `y`.
+    * When prompted for database connection settings, use the same database server or cluster you used for the first API Portal instance.
+    * The installation checks the database connection and if it is successful for any node other than the first node, it asks you to confirm that this is a HA setup. Enter `y`.
 
-1. Install the EasyBlog and EasyDiscuss components on each other node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
+4. Install the EasyBlog and EasyDiscuss components on each other node as detailed in [Install Joomla! components](/docs/apim_installation/apiportal_install/install_software/#install-joomla-components).
 
 #### Upgrade API Portal for HA as a software installation
 
@@ -77,7 +77,7 @@ You must situate the load balancer between the two API Portal instances.
 
 ## Failover scenarios
 
-This topic describes the expected behavior in case of a failover in API Portal high-availability (HA) deployment in a single datacenter. 
+This topic describes the expected behavior in case of a failover in API Portal high-availability (HA) deployment in a single datacenter.
 
 ### One API Portal instance is down
 
@@ -87,9 +87,9 @@ In this scenario, one of the API Portal instances in the datacenter goes down:
 
 The following applies on this scenario:
 
-- The API Portal instance that is down can no longer handle requests.
-- All requests are handled by the remaining API Portal instances.
-- You must restart the API Portal instance that is down.
+* The API Portal instance that is down can no longer handle requests.
+* All requests are handled by the remaining API Portal instances.
+* You must restart the API Portal instance that is down.
 
 ### One database node is down
 
@@ -101,8 +101,8 @@ When a database node has been down and absent from a cluster for a time, you mus
 
 The following applies in this scenario:
 
-- The database cluster tolerates the loss of a node in the cluster, and ensures 100% data consistency.
-- You must restart the database node that is down, and connect it to the cluster to synchronize and start operation.
+* The database cluster tolerates the loss of a node in the cluster, and ensures 100% data consistency.
+* You must restart the database node that is down, and connect it to the cluster to synchronize and start operation.
 
 ### The whole datacenter is down
 
@@ -112,9 +112,9 @@ In this scenario, the whole datacenter goes down:
 
 The following applies in this scenario:
 
-- No requests can be handled.
-- Load balancer must properly handle failures.
-- No data can be deployed until the system is back to normal.
+* No requests can be handled.
+* Load balancer must properly handle failures.
+* No data can be deployed until the system is back to normal.
 
 #### Restart the datacenter
 

--- a/content/en/docs/cass_admin/_index.md
+++ b/content/en/docs/cass_admin/_index.md
@@ -10,3 +10,5 @@ Apache Cassandra is a highly scalable distributed NO-SQL database that
 provides high service availability.
 
 Cassandra is required to store data for API Manager. You can optionally use Cassandra to store data for API Gateway components such as the Key Property Store (KPS), OAuth, and API keys.
+
+For details on how to install the Cassandra database see [Install an Apache Cassandra database](/docs/apim_installation/apigtw_install/cassandra_install/).

--- a/content/en/docs/cass_admin/cassandra_architecture.md
+++ b/content/en/docs/cass_admin/cassandra_architecture.md
@@ -7,13 +7,32 @@ description: >
   This section describes the Cassandra deployment architectures supported by API Gateway.
 ---
 
-The following table provides a summary.
+This section provides a summary of the deployment architectures.
 
-|Deployment|Description|Usage|
-|--- |--- |--- |
-|Standalone|One API Gateway instance only. This is the default.|<ul><li>Development environment</li><li>Production environment with one API Gateway instance</li></ul>|
-|High availability with local storage|Multiple API Gateway instances in a group, each API Gateway instance on different hosts, with a Cassandra storage node local to each API Gateway host.|<ul><li>Pre-production environment</li><li>Production environment</li></ul>|
-|High availability with remote storage|Multiple API Gateway instances in a group, each API Gateway instance on different hosts, with Cassandra storage nodes on remote hosts.|<ul><li>Pre-production environment</li><li>Production environment</li></ul>|
+## Standalone
+
+One API Gateway instance only. This is the default.
+
+Usage:
+
+* Development environment
+* Production environment with one API Gateway instance
+
+## High availability with local storage
+
+Multiple API Gateway instances in a group, each API Gateway instance on different hosts, with a Cassandra storage node local to each API Gateway host.
+
+Usage:
+
+* Pre-production environment
+* Production environment
+
+## High availability with remote storage
+
+Multiple API Gateway instances in a group, each API Gateway instance on different hosts, with Cassandra storage nodes on remote hosts.
+
+* Pre-production environment
+* Production environment
 
 You can use one Cassandra cluster to store data from one or multiple API Gateway groups and one or multiple API Gateway domains. Your Cassandra topology does not need to match your API Gateway topology.
 
@@ -24,7 +43,7 @@ Windows is supported only for a limited set of developer tools. API Gateway and 
 on Windows that you have configured with your API Gateway installation.
 {{< /alert>}}
 
-For details on hosting Cassandra in datacenters, see [Configure API Management in multiple datacenters](/bundle/APIGateway_77_InstallationGuide_allOS_en_HTML5/page/Content/InstallGuideTopics/TemplateTopics/post-install/post_multi-datacenter.htm).
+For details on hosting Cassandra in datacenters, see [Configure API Management in multiple datacenters](/docs/apimgmt_multi_dc/).
 
 ## Cassandra in standalone mode
 
@@ -32,18 +51,18 @@ Cassandra is configured in non-HA standalone mode when deployed alongside a sing
 
 To configure Cassandra in standalone mode, perform the following steps:
 
-1. Ensure Cassandra is installed on the local node (along with API Gateway). For details, see [Install an Apache Cassandra database](/bundle/APIGateway_77_InstallationGuide_allOS_en_HTML5/page/Content/InstallGuideTopics/cassandra_install.htm).
-2. Start Cassandra before starting API Gateway. For details, see [Manage Apache Cassandra](/docs/cass_admin/cassandra_manage).
-3. Start API Gateway. For details, see the [API Gateway Installation Guide](/bundle/APIGateway_77_InstallationGuide_allOS_en_HTML5/).
+1. Ensure Cassandra is installed on the local node along with API Gateway.
+2. Start Cassandra before starting API Gateway.
+3. Start API Gateway.
 
 The next steps depend on your installation setup type:
 
-- In a Standard or Complete setup that includes the QuickStart tutorial, the default configuration attempts to connect to Cassandra running on `localhost`.
-- In a Custom setup without the QuickStart tutorial, you must configure the connection in Policy Studio. For more details, see [Connect to API Gateway for the first time](/docs/cass_admin/cassandra_manage/#connect-to-api-gateway-for-the-first-time).
+* In a Standard or Complete setup that includes the QuickStart tutorial, the default configuration attempts to connect to Cassandra running on `localhost`.
+* In a Custom setup without the QuickStart tutorial, you must configure the connection in Policy Studio. For more details, see [Connect to API Gateway for the first time](/docs/cass_admin/cassandra_manage/#connect-to-api-gateway-for-the-first-time).
 
 To use Cassandra with API Manager, see [Configure a highly available Cassandra cluster](/docs/cass_admin/cassandra_config/). This is configured by default when API Manager is installed along with the QuickStart tutorial.
 
-To use Cassandra with OAuth, see [Deploy OAuth configuration](/bundle/APIGateway_77_OAuthUserGuide_allOS_en_HTML5/page/Content/OAuthGuideTopics/deploy_oauth_config.htm).
+To use Cassandra with OAuth, see [Deploy OAuth configuration](docs/apim_policydev/apigw_oauth/gw_server/#deploy-oauth-services).
 
 The following diagram shows Cassandra in standalone mode with a default standard setup:
 
@@ -67,11 +86,11 @@ The following diagram shows local Cassandra HA mode:
 
 In remote Cassandra HA, Cassandra runs on a different host from API Gateway. The main differences when installing and configuring remote Cassandra are:
 
-- You must provision separate host machines for Cassandra and API Gateway. However, the data can be stored outside the DMZ, and there might be improved performance.
-- You might need to open ports in the firewall to connect to Cassandra outside the DMZ. For more details, see [Configure a highly available Cassandra cluster](/docs/cass_admin/cassandra_config/).
-- You do not have to use the Cassandra component supplied by the API Gateway installer.
-- You can configure the remote node using the `setup-cassandra` script supplied by the API Gateway installation. For more details, see [setup-cassandra script reference](/docs/cass_admin/cassandra_setup_script/). Alternatively, you can perform all necessary Cassandra configuration changes manually.
-- You must update the API Gateway Cassandra client settings in Policy Studio to connect to the remote Cassandra host nodes.
+* You must provision separate host machines for Cassandra and API Gateway. However, the data can be stored outside the DMZ, and there might be improved performance.
+* You might need to open ports in the firewall to connect to Cassandra outside the DMZ. For more details, see [Configure a highly available Cassandra cluster](/docs/cass_admin/cassandra_config/).
+* You do not have to use the Cassandra component supplied by the API Gateway installer.
+* You can configure the remote node using the `setup-cassandra` script supplied by the API Gateway installation. For more details, see [setup-cassandra script reference](/docs/cass_admin/cassandra_setup_script/). Alternatively, you can perform all necessary Cassandra configuration changes manually.
+* You must update the API Gateway Cassandra client settings in Policy Studio to connect to the remote Cassandra host nodes.
 
 The following diagram shows remote Cassandra HA mode:
 
@@ -81,35 +100,33 @@ The following diagram shows remote Cassandra HA mode:
 
 You can use a local or remote Cassandra HA configuration. The example Cassandra HA configuration in the diagrams consists of the following:
 
-- Three Cassandra nodes in a single cluster.
-- Three host machines with network addresses: `ipA` (seed node), `ipB`, and `ipC`.
-- Replication factor of `3`. Each node holds 100% of the data.
-- Default values in `cassandra.yaml` for:
-  - Server-server communication:
+* Three Cassandra nodes in a single cluster.
+* Three host machines with network addresses: `ipA` (seed node), `ipB`, and `ipC`.
+* Replication factor of `3`. Each node holds 100% of the data.
+* Default values in `cassandra.yaml` for:
+    * Server-server communication:
     `listen_address` set to IP address
     `storage_port` set to `7000`
     `ssl_storage_port`: `7001` (when TLS v1.2 is configured)
-  - Client-server communication: `native_transport_port` of `9042`
-  - JMX monitoring on `localhost:7199`
+    * Client-server communication: `native_transport_port` of `9042`
+    * JMX monitoring on `localhost:7199`
 
 More information:
 
-- `ipA`, `ipB`, and `ipC` are placeholders for real host machines on your network. You can specify IP addresses or host names.
-- You must have at least one designated seed node. Seeds nodes are required at runtime when a node is added to the cluster. You can add more or change designation later.
-- You can change the server-server port, but it must be the same across the cluster.
-- For Cassandra administration, you must gain local access to the host machine (for example, using SSH) to perform administration tasks. This includes using `nodetool` to access the Cassandra cluster over JMX.
+* `ipA`, `ipB`, and `ipC` are placeholders for real host machines on your network. You can specify IP addresses or host names.
+* You must have at least one designated seed node. Seeds nodes are required at runtime when a node is added to the cluster. You can add more or change designation later.
+* You can change the server-server port, but it must be the same across the cluster.
+* For Cassandra administration, you must gain local access to the host machine (for example, using SSH) to perform administration tasks. This includes using `nodetool` to access the Cassandra cluster over JMX.
 
 ### API Gateway configuration
 
 API Gateway acts as a client of the Cassandra cluster as follows:
 
-- Client failover
+* Client failover
+  : API Gateway can fail over to any of the Cassandra nodes for service. Each API Gateway is configured with the connection details of each Cassandra host.
 
-    API Gateway can fail over to any of the Cassandra nodes for service. Each API Gateway is configured with the connection details of each Cassandra host.
-
-- Strong consistency
-
-    Cassandra read and write consistency levels are both set to `QUORUM`. This, along with the replication factor of `3`, enables full availability in the event of one node loss.
+* Strong consistency
+  : Cassandra read and write consistency levels are both set to `QUORUM`. This, along with the replication factor of `3`, enables full availability in the event of one node loss.
 
 You can have any number of gateway instances (all running either locally or remote to Cassandra). However, you must have at least two gateway instances for HA. This also applies to API Manager.
 

--- a/content/en/docs/cass_admin/cassandra_bestpractices.md
+++ b/content/en/docs/cass_admin/cassandra_bestpractices.md
@@ -16,8 +16,8 @@ The clocks of the system across all Cassandra cluster machines and the clocks of
 
 Failing to synchronize the clocks will result in:
 
-- Faults in data synchronization.
-- Failure to start or configure the machines correctly.
+* Faults in data synchronization.
+* Failure to start or configure the machines correctly.
 
 The clock synchronization requires the use of a time service, such as NTP (Network Time Protocol), to ensure that the time is synchronized across all machines in the cluster.
 
@@ -25,9 +25,9 @@ You must also perform a health check of the clock drift between nodes on a regul
 
 ### User account
 
-- You must create a specific UNIX user account for the Cassandra database.
-- This user account must own all Cassandra related files, and it must be used to run the Cassandra process.
-- This guide refers to this user account as `cassandra_user`.
+* You must create a specific UNIX user account for the Cassandra database.
+* This user account must own all Cassandra related files, and it must be used to run the Cassandra process.
+* This guide refers to this user account as `cassandra_user`.
 
 ### Required system tuning
 

--- a/content/en/docs/cass_admin/cassandra_config.md
+++ b/content/en/docs/cass_admin/cassandra_config.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure  a highly available Cassandra cluster"
+title: "Configure a highly available Cassandra cluster"
 linkTitle: "Configure HA"
 weight: 2
 date: 2019-06-05
@@ -10,9 +10,9 @@ description: >
 
 To tolerate the loss of one Cassandra node and to ensure 100% data consistency, API Gateway requires at a minimum the following Cassandra cluster configuration running in a production class environment:
 
-- Three Cassandra nodes (with one seed node)
-- `Replication factor` setting set to `3`, so each node holds 100% of the data.
-- `QUORUM` read/write consistency to ensure that you are reading from a quorum of Cassandra nodes (two) every time.
+* Three Cassandra nodes (with one seed node)
+* `Replication factor` setting set to `3`, so each node holds 100% of the data.
+* `QUORUM` read/write consistency to ensure that you are reading from a quorum of Cassandra nodes (two) every time.
   {{% alert title="Caution" color="warning" %}}
   `Eventual` consistency is not supported in a production environment due to a risk of stale or missing data.
   {{% /alert %}}
@@ -23,13 +23,11 @@ If one Cassandra node fails or needs to be restarted, the cluster continues to o
 
 The following general guidelines apply to configuring a Cassandra HA cluster:
 
-- Decide on the number of Cassandra nodes, and install and configure the Cassandra database on each node.
-- Decide on the number of gateway nodes, and install and configure them (local or remote to Cassandra).
-  - It is recommended that you configure a Cassandra HA cluster with three Cassandra nodes, and at least two API Gateway instances (local or remote). For details, see [Cassandra deployment architectures](/docs/cass_admin/cassandra_architecture/).
-- Create a HA API Gateway environment.
-- Configure the Cassandra client settings in Policy Studio for the API Gateway group.
-
-For details on how to install an Apache Cassandra database or how to create a HA API Gateway environment, see [API Gateway Installation Guide](/bundle/APIGateway_77_InstallationGuide_allOS_en_HTML5/).
+* Decide on the number of Cassandra nodes, and install and configure the Cassandra database on each node.
+* Decide on the number of gateway nodes, and install and configure them (local or remote to Cassandra).
+    * It is recommended that you configure a Cassandra HA cluster with three Cassandra nodes, and at least two API Gateway instances (local or remote). For details, see [Cassandra deployment architectures](/docs/cass_admin/cassandra_architecture/).
+* Create a HA API Gateway environment.
+* Configure the Cassandra client settings in Policy Studio for the API Gateway group.
 
 ## Example of a HA setup using three Cassandra nodes
 
@@ -136,22 +134,24 @@ In Policy Studio, open your gateway group configuration.
 1. Select **Server Settings > Cassandra > Authentication**, and enter your Cassandra user name and password (both default to `cassandra`).
 2. Select **Server Settings > Cassandra > Hosts**, and add an address for each Cassandra node in the cluster (`ipA`, `ipB` and `ipC` in this example).
 
-You can automate these steps by running the `updateCassandraSettings.py` script against a deployment package (`.fed`). 
+You can automate these steps by running the `updateCassandraSettings.py` script against a deployment package (`.fed`).
 
 #### Configure the API Gateway Cassandra consistency levels
 
-1. Ensure that the **API Server** KPS collection has been created under **Environment Configuration > Key Property Stores**. This is required to configure Cassandra consistency levels, and is created automatically if you installed the **Complete** setup type. If you installed the **Custom** or **Standard** setup, you must configure OAuth or API Manager settings in Policy Studio to create the required KPS collections. For more details, see:
+1. For the **Complete** setup type installation, configure Cassandra consistency levels by ensuring that the **API Server** KPS collection has been created under **Environment Configuration > Key Property Stores**.
 
-    - [Deploy OAuth configuration](/bundle/APIGateway_77_OAuthUserGuide_allOS_en_HTML5/page/Content/OAuthGuideTopics/deploy_oauth_config.htm).
-    - [Configure API Manager Cassandra client settings](#configure-api-manager-cassandra-client-settings)
+    If you installed the **Custom** or **Standard** setup, you must configure OAuth or API Manager settings in Policy Studio to create the required KPS collections. For more details, see:
+
+    * [Deploy OAuth configuration](/bundle/APIGateway_77_OAuthUserGuide_allOS_en_HTML5/page/Content/OAuthGuideTopics/deploy_oauth_config.htm).
+    * [Configure API Manager Cassandra client settings](#configure-api-manager-cassandra-client-settings)
 
 2. Select **Environment Configuration > Key Property Stores > API Server > Data Sources > Cassandra Storage**, and click **Edit**.
 3. In the **Read Consistency Level** and **Write Consistency Level** fields, select **QUORUM**.
 4. Repeat this step for each KPS collection using Cassandra (for  example, **Key Property Stores > OAuth**, or **API Portal** for API Manager). This also applies to any custom KPS collections that you have created.
 5. If you are using OAuth and Cassandra, you must also configure quorum consistency for all OAuth2 stores under **Libraries > OAuth2 Stores**:
-    - **Access Token Stores > OAuth Access Token Store**
-    - **Authorization Code Stores > Authz Code Store**
-    - **Client Access Token Stores > OAuth Client Access Token Store**
+    * **Access Token Stores > OAuth Access Token Store**
+    * **Authorization Code Stores > Authz Code Store**
+    * **Client Access Token Stores > OAuth Client Access Token Store**
   
     By default, OAuth uses EhCache instead of Cassandra. For more details on OAuth, see the [API Gateway OAuth User Guide](/bundle/APIGateway_77_OAuthUserGuide_allOS_en_HTML5/).
 
@@ -184,13 +184,13 @@ To update the Cassandra client configuration for API Manager, perform the follow
 Do not start this instance, and do not configure API Manager for this instance in Policy Studio.
 {{% /alert %}}
 10. Before starting the second API Manager-enabled instance, ensure that each instance has unique ports in the `envSettings.props` file. For example:
-    - Edit the `envSettings.props` file for the gateway instance in the following directory:
+    * Edit the `envSettings.props` file for the gateway instance in the following directory:
 
       ```
       INSTALL_DIR/apigateway/groups/<group-n>/<instance-m>/conf/envSettings.props
       ```
 
-    - Add the API Manager ports. For example, the defaults are:
+    * Add the API Manager ports. For example, the defaults are:
 
       ```
       #API Manager Port

--- a/content/en/docs/cass_admin/cassandra_manage.md
+++ b/content/en/docs/cass_admin/cassandra_manage.md
@@ -31,15 +31,15 @@ To start Cassandra in the foreground, run the following command:
 ./cassandra -f
 ```
 
-For more details, see <https://wiki.apache.org/cassandra/RunningCassandra>.
+For more details, see [Running Cassandra in the Apache Cassandra Wiki](https://wiki.apache.org/cassandra/RunningCassandra).
 
 ### Start Cassandra as a service
 
 To install Cassandra as a service, you must install and configure the appropriate startup script for your system. For example, see the following example startup scripts:
 
-- **CentOS**:
+* **CentOS**:
 [https://support.axway.com/kb/178063/language/en](https://support.axway.com/kb/178063/language/en "https://support.axway.com/kb/178063/language/en")
-- **Debian**:
+* **Debian**:
 [https://github.com/apache/cassandra/blob/cassandra-2.2/debian/init](https://github.com/apache/cassandra/blob/cassandra-2.2/debian/init "https://github.com/apache/cassandra/blob/cassandra-2.2/debian/init")
 
 You must have root or sudo permissions to start Cassandra as a service. For example, typically the command to start Cassandra as a service is as follows:
@@ -52,15 +52,15 @@ sudo service cassandra start
 
 1. Find the Cassandra Java process ID (PID):
 
-```
-ps auwx | grep cassandra
-```
+    ```
+    ps auwx | grep cassandra
+    ```
 
 2. Run the following command:
 
-```
-sudo kill *pid*
-```
+    ```
+    sudo kill *pid*
+    ```
 
 ### Stop Cassandra as a service
 
@@ -93,5 +93,5 @@ For more details on configuring **Server Settings** in the Policy Studio client,
 
 For more details on Apache Cassandra, see the following:
 
-- <http://cassandra.apache.org/>
-- [http://docs.datastax.com/en/cassandra/2.2/](http://docs.datastax.com/en/cassandra/2.2/)
+* [Apache Cassandra](http://cassandra.apache.org/) documentation.
+* [Datastax](http://docs.datastax.com/en/cassandra/2.2/) documentation.

--- a/content/en/docs/cass_admin/cassandra_ops.md
+++ b/content/en/docs/cass_admin/cassandra_ops.md
@@ -68,27 +68,27 @@ configuration). Perform the following steps:
 
 You can enable Cassandra debug logging using any of the following approaches:
 
-- **logback.xml**
+* **logback.xml**
   You can specify a `logger` in the `cassandra/conf/logback.xml` configuration file as follows:
   
   ```
   <logger name "org.apache.cassandra.transport" level=DEBUG/>
   ```
 
-- **nodetool**
+* **nodetool**
   You can use the `nodetool setlogginglevel` command as follows:
 
   ```
   nodetool setlogginglevel org.apache.cassandra.transport DEBUG
   ```
 
-- **JConsole**
+* **JConsole**
   The JConsole tool enables you to configure Cassandra logging using JMX. For example, you can invoke `setLoggingLevel` and specify `org.apache.cassandra.db.StorageServiceMBean` and `DEBUG` as parameters. For more details, see the next section.
 
 For more details on enabling logging, see the following, which also applies to Cassandra 2.2:
 
-- [Configuring logging](https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configLoggingLevels\_r.html)
-- [Locking Down Apache Cassandra Logging](http://thelastpickle.com/blog/2016/02/10/locking-down-apache-cassandra-logging.html)
+* [Configuring logging](https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configLoggingLevels\_r.html)
+* [Locking Down Apache Cassandra Logging](http://thelastpickle.com/blog/2016/02/10/locking-down-apache-cassandra-logging.html)
 
 ## Monitor a Cassandra cluster using JMX
 

--- a/content/en/docs/cass_admin/cassandra_setup_script.md
+++ b/content/en/docs/cass_admin/cassandra_setup_script.md
@@ -23,13 +23,11 @@ The following prerequisites apply for the `setup-cassandra` script:
 
 ### Python
 
-- Cassandra 2.2.5 requires Python 2.7.x *(up to 2.7.10)*
-- Cassandra 2.2.8 requires Python 2.7.x *(up to the latest)*
-- Cassandra 2.2.12 requires Python 2.7.x *(up to the latest)*
+* Cassandra 2.2.5 requires Python 2.7.x *(up to 2.7.10)*
+* Cassandra 2.2.8 requires Python 2.7.x *(up to the latest)*
+* Cassandra 2.2.12 requires Python 2.7.x *(up to the latest)*
 
-{{% alert title="Note" %}}
-API Gateway 7.7 supports Cassandra 2.2.12. API Gateway 7.5.3 supports Cassandra versions 2.2.5 and 2.2.8.
-{{% /alert %}}
+{{% alert title="Note" %}}API Gateway 7.7 supports Cassandra 2.2.12. API Gateway 7.5.3 supports Cassandra versions 2.2.5 and 2.2.8.{{% /alert %}}
 
 ### User name and password authentication
 
@@ -151,15 +149,15 @@ If you are setting up a Cassandra HA cluster, you must replicate the `system_au
 
 To configure TLS v1.2 encryption, you will need:
 
-- A private key and certificate for every Cassandra node in the cluster.
-- A certificate for the Certification Authority (CA) used to generate the node certificate.
+* A private key and certificate for every Cassandra node in the cluster.
+* A certificate for the Certification Authority (CA) used to generate the node certificate.
 
 You can use Policy Studio to create the necessary certificates and keys or any other suitable method for generating certificates.
 
 You must export and save the node certificate and private key as a PKCS12 file, and save the CA certificate as a PEM file as follows:
 
-- For node-to-node: `server.p12` and `server-ca.pem`
-- For client-to-node: `client.p12` and `client-ca.pem`
+* For node-to-node: `server.p12` and `server-ca.pem`
+* For client-to-node: `client.p12` and `client-ca.pem`
 
 You must place these files into the same directory where you run the setup-cassandra script from.
 
@@ -189,9 +187,9 @@ When the Cassandra cluster has been configured to use client-to-node TLS/SSL enc
 
 If client-to-node TLS/SSL encryption has been enabled, the `setup-cassandra` script creates a configuration file (`cqlshrc`) with the necessary configuration to enable TLS/SSL encryption. However, you must provide following files to configure `cqlsh` for TLS/SSL:
 
-- `client-ca.pem`: PEM file containing CA certificate
-- `cqlsh-cert.pem`: PEM file containing client certificate for `cqlsh`
-- `cqlsh-key.pem`: PEM file containing private key of client certificate for `cqlsh`
+* `client-ca.pem`: PEM file containing CA certificate
+* `cqlsh-cert.pem`: PEM file containing client certificate for `cqlsh`
+* `cqlsh-key.pem`: PEM file containing private key of client certificate for `cqlsh`
 
 ## Updated Cassandra configuration
 
@@ -199,41 +197,41 @@ This section shows the updates that the `setup-cassandra` script makes to the `c
 
 ### General settings
 
-- `seed_provider`, `parameters`, `seeds`: <*IP address of seed node*>
-- `start_native_transport`: `true`
-- `native_transport_port`: `9042`
-- `listen_address`: IP address of the node
-- `rpc_address`: IP address of the node
-- `authenticator`: `org.apache.cassandra.auth.PasswordAuthenticator`
-- `authorizer`: `org.apache.cassandra.auth.CassandraAuthorizer`
+* `seed_provider`, `parameters`, `seeds`: <*IP address of seed node*>
+* `start_native_transport`: `true`
+* `native_transport_port`: `9042`
+* `listen_address`: IP address of the node
+* `rpc_address`: IP address of the node
+* `authenticator`: `org.apache.cassandra.auth.PasswordAuthenticator`
+* `authorizer`: `org.apache.cassandra.auth.CassandraAuthorizer`
 
 ### Node-to-node traffic encryption
 
 If node-to-node TLS/SSL traffic encryption is enabled:
 
-- `server_encryption_options`: Specified options
-- `internode_encryption`: all
-- `keystore`: <`server-keystore.jks`>
-- `keystore_password`: Randomly generated password
-- `truststore`: <`server-truststore.jks`>
-- `truststore_password`: Randomly generated password
-- `protocol`: TLS
-- `store_type`: JKS
-- `algorithm`: SunX509
-- `require_client_auth`: true
+* `server_encryption_options`: Specified options
+* `internode_encryption`: all
+* `keystore`: <`server-keystore.jks`>
+* `keystore_password`: Randomly generated password
+* `truststore`: <`server-truststore.jks`>
+* `truststore_password`: Randomly generated password
+* `protocol`: TLS
+* `store_type`: JKS
+* `algorithm`: SunX509
+* `require_client_auth`: true
 
 ### Client-to-node traffic encryption
 
 If client-to-node TLS/SSL traffic encryption is enabled:
 
-- `client_encryption_options`: Specified options
-- `enabled`: true
-- `optional`: false
-- `keystore`: <`client-keystore.jks`>
-- `keystore_password`: Randomly generated password
-- `truststore`: <`client-truststore.jks`>
-- `truststore_password`: Randomly generated password
-- `protocol`: TLS
-- `store_type`: JKS
-- `algorithm`: SunX509
-- `require_client_auth`: true
+* `client_encryption_options`: Specified options
+* `enabled`: true
+* `optional`: false
+* `keystore`: <`client-keystore.jks`>
+* `keystore_password`: Randomly generated password
+* `truststore`: <`client-truststore.jks`>
+* `truststore_password`: Randomly generated password
+* `protocol`: TLS
+* `store_type`: JKS
+* `algorithm`: SunX509
+* `require_client_auth`: true

--- a/content/en/docs/central/add_hybrid_env.md
+++ b/content/en/docs/central/add_hybrid_env.md
@@ -6,27 +6,27 @@ date: 2019-07-30
 description: Learn how to add your private cloud hybrid environment to AMPLIFY Central, so that you can manage your microservices, and any related APIs they expose.
 ---
 
-*Estimated reading time: 8 minutes*
+*Estimated reading time*: 8 minutes
 
 {{< alert title="Public beta" color="warning" >}}This feature is currently in **public beta** and not yet available for production use.{{< /alert >}}
 
 ## Before you start
 
-- Read [AMPLIFY Central mesh governance overview](/docs/central/hybrid_overview).
-- You will need a private cloud Kubernetes cluster that meets the minimum requirements for an AMPLIFY Central hybrid environment, and a client system from which you can access and manage the cluster remotely. See [Build your hybrid environment](/docs/central/build_hybrid_env).
-- You will need a basic understanding of OAuth authorization ([RFC 6749](https://tools.ietf.org/html/rfc6749)) and JWT ([RFC 7523](https://tools.ietf.org/html/rfc7523)).
-- You will need to be familiar with Kubernetes and Helm, including running Helm and kubectl commands.
-- You will need an administrator account for AMPLIFY Central.
+* Read [AMPLIFY Central mesh governance overview](/docs/central/hybrid_overview).
+* You will need a private cloud Kubernetes cluster that meets the minimum requirements for an AMPLIFY Central hybrid environment, and a client system from which you can access and manage the cluster remotely. See [Build your hybrid environment](/docs/central/build_hybrid_env).
+* You will need a basic understanding of OAuth authorization ([RFC 6749](https://tools.ietf.org/html/rfc6749)) and JWT ([RFC 7523](https://tools.ietf.org/html/rfc7523)).
+* You will need to be familiar with Kubernetes and Helm, including running Helm and kubectl commands.
+* You will need an administrator account for AMPLIFY Central.
 
 ## Objectives
 
 Learn how to add your private cloud hybrid environment to AMPLIFY Central, so that you can manage your microservices, and any related APIs they expose, from AMPLIFY Central in AMPLIFY Central public cloud.
 
-- Add your environment to AMPLIFY Central and download the generated hybrid kit
-- Generate a key pair and secret for the domain edge gateway and deploy it into the Istio namespace
-- Generate key pairs and secrets for the Axway mesh agents and deploy them into the mesh agent namespace
-- Deploy the Axway proprietary service mesh layer into your environment
-- Create and test an API proxy for the API exposed by a demo microservice
+* Add your environment to AMPLIFY Central and download the generated hybrid kit
+* Generate a key pair and secret for the domain edge gateway and deploy it into the Istio namespace
+* Generate key pairs and secrets for the Axway mesh agents and deploy them into the mesh agent namespace
+* Deploy the Axway proprietary service mesh layer into your environment
+* Create and test an API proxy for the API exposed by a demo microservice
 
 ## Add your environment to AMPLIFY Central
 
@@ -41,11 +41,11 @@ Watch the animation to learn how to do this in AMPLIFY Central UI.
 Download the hybrid kit to your client system and unzip it to a unique directory. For example:
 
 ```
-$ ls *.zip
+ls *.zip
 e4fd7216693f50360169492633ab0122-override.zip
-$ unzip e4fd7216693f50360169492633ab0122-override.zip -d e4fd7216693f50360169492633ab0122
-$ cd e4fd7216693f50360169492633ab0122
-$ ls
+unzip e4fd7216693f50360169492633ab0122-override.zip -d e4fd7216693f50360169492633ab0122
+cd e4fd7216693f50360169492633ab0122
+ls
 hybridOverride.yaml  istioOverride.yaml
 ```
 
@@ -54,32 +54,33 @@ hybridOverride.yaml  istioOverride.yaml
 To expose an HTTPS endpoint of a service within your environment to external traffic, you need a public certificate and private key for the domain where your environment is hosted, and a TLS secret based on the key pair.
 
 1. Create an X.509 certificate and key for your domain (for example, using [Let's Encrypt](https://letsencrypt.org/)).
-    - The domain certificate must match the domain (FQDN) of your environment.
-    - The public key certificate must be PEM encoded and match the given private key.
-1. Create the Istio namespace. This is the namespace where Istio will be deployed.
+    * The domain certificate must match the domain (FQDN) of your environment.
+    * The public key certificate must be PEM encoded and match the given private key.
+2. Create the Istio namespace. This is the namespace where Istio will be deployed.
 
     Usage: `kubectl create namespace NAMESPACE_NAME`
 
-    - The default value of `NAMESPACE_NAME` is `istio-system` and this value is used later when the helm upgrade deployment steps are executed in [Deploy the service mesh and Axway mesh agents](#deploy-the-service-mesh-and-axway-mesh-agents).
+    The default value of `NAMESPACE_NAME` is `istio-system` and this value is used later when the helm upgrade deployment steps are executed in [Deploy the service mesh and Axway mesh agents](#deploy-the-service-mesh-and-axway-mesh-agents).
 
     Example:
 
     ```
-    $ kubectl create namespace istio-system
+    kubectl create namespace istio-system
     namespace/istio-system created
     ```
-1. Create a Kubernetes TLS secret to hold the public certificate and private key, and deploy it into the Istio namespace.
+
+3. Create a Kubernetes TLS secret to hold the public certificate and private key, and deploy it into the Istio namespace.
 
     Usage: `kubectl create secret tls SECRET_NAME -n NAMESPACE_NAME --key /PATH/TO/KEY/FILE --cert /PATH/TO/CERT/FILE`
 
-    - `SECRET_NAME` must match the field `secretName` in the `istioOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit. The `secretName` in the Helm chart is generated from your domain name, for example, `kubernetes-cluster-example-certs` for the domain `kubernetes-cluster.example.com`.
-    
+    `SECRET_NAME` must match the field `secretName` in the `istioOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit. The `secretName` in the Helm chart is generated from your domain name, for example, `kubernetes-cluster-example-certs` for the domain `kubernetes-cluster.example.com`.
+
     Example:
 
     ```
-    $ kubectl create secret tls kubernetes-cluster-example-certs -n istio-system --key kubernetes-cluster.example.com.key.pem --cert kubernetes-cluster.example.com.cert.pem
+    kubectl create secret tls kubernetes-cluster-example-certs -n istio-system --key kubernetes-cluster.example.com.key.pem --cert kubernetes-cluster.example.com.cert.pem
     secret/kubernetes-cluster-example-certs created
-    $ kubectl get secrets -n istio-system
+    kubectl get secrets -n istio-system
     NAME                               TYPE                                  DATA   AGE
     kubernetes-cluster-example-certs   kubernetes.io/tls                     2      4m
     default-token-jvw9m                kubernetes.io/service-account-token   3      27m
@@ -100,12 +101,12 @@ AMPLIFY Central uses the public key to authenticate signed JWT tokens from the a
 Use `openssl` to generate a public certificate and private key for the service discovery agent (SDA) . The following example uses the password `changeme`:
 
 ```
-$ mkdir sdacerts
-$ cd sdacerts/
-$ echo -n "changeme" > password
-$ openssl genrsa -des3 -out private_key.pem -passout file:password 2048
+mkdir sdacerts
+cd sdacerts/
+echo -n "changeme" > password
+openssl genrsa -des3 -out private_key.pem -passout file:password 2048
 Generating RSA private key...
-$ openssl rsa -pubout -in  private_key.pem -passin file:password -out public_key.der -outform der && base64 public_key.der > public_key
+openssl rsa -pubout -in  private_key.pem -passin file:password -out public_key.der -outform der && base64 public_key.der > public_key
 writing RSA key
 ```
 
@@ -114,11 +115,11 @@ writing RSA key
 Use `openssl` to generate a public certificate and private key for the configuration synchronization agent (CSA):
 
 ```
-$ mkdir csacerts
-$ cd csacerts/
-$ openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
+mkdir csacerts
+cd csacerts/
+openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
 ...
-$ openssl rsa -pubout -in private_key.pem -out public_key.der -outform der && base64 public_key.der > public_key
+openssl rsa -pubout -in private_key.pem -out public_key.der -outform der && base64 public_key.der > public_key
 writing RSA key
 ```
 
@@ -128,12 +129,12 @@ Create the namespace where the Axway mesh agents will be deployed.
 
 Usage: `kubectl create namespace NAMESPACE_NAME`
 
-- The default value for `NAMESPACE_NAME` is `apic-control` and this value is used later when the helm upgrade deployment steps are executed in [Deploy the service mesh and Axway mesh agents](#deploy-the-service-mesh-and-axway-mesh-agents).
+The default value for `NAMESPACE_NAME` is `apic-control` and this value is used later when the helm upgrade deployment steps are executed in [Deploy the service mesh and Axway mesh agents](#deploy-the-service-mesh-and-axway-mesh-agents).
 
 Example:
 
 ```
-$ kubectl create namespace apic-control
+kubectl create namespace apic-control
 namespace/apic-control created
 ```
 
@@ -145,29 +146,29 @@ Create Kubernetes secrets to hold the mesh agents' public certificates and priva
 
 Usage: `kubectl create secret generic SECRET_NAME --namespace NAMESPACE_NAME  --from-file=publicKey=/PATH/TO/PUBLIC/KEY/FILE --from-file=privateKey=/PATH/TO/PRIVATE/KEY/FILE  --from-file=password=PASSWORD_FILE --from-literal=password=PASSWORD -o yaml`
 
-- Each `SECRET_NAME` must match the corresponding SDA or CSA field `keysSecretName` in the `hybridOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit.
-The SDA default value of `keysSecretName` is `sda-secrets`.
-The CSA default value of `keysSecretName` is `csa-secrets`.
-To change the secret store names, edit the `keysSecretName` values in the `hybridOverride.yaml` file before you execute the helm upgrade deployment steps.
+* Each `SECRET_NAME` must match the corresponding SDA or CSA field `keysSecretName` in the `hybridOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit.
+* The SDA default value of `keysSecretName` is `sda-secrets`.
+* The CSA default value of `keysSecretName` is `csa-secrets`.
+* To change the secret store names, edit the `keysSecretName` values in the `hybridOverride.yaml` file before you execute the helm upgrade deployment steps.
 
 Example for SDA:
 
 ```
-$ cd sdacerts/
-$ kubectl create secret generic sda-secrets --namespace apic-control --from-file=publicKey=public_key --from-file=privateKey=private_key.pem --from-file=password="password" -o yaml
+cd sdacerts/
+kubectl create secret generic sda-secrets --namespace apic-control --from-file=publicKey=public_key --from-file=privateKey=private_key.pem --from-file=password="password" -o yaml
 ```
 
 Example for CSA:
 
 ```
-$ cd csacerts/
-$ kubectl create secret generic csa-secrets --namespace apic-control --from-file=publicKey=public_key --from-file=privateKey=private_key.pem --from-literal=password="" -o yaml
+cd csacerts/
+kubectl create secret generic csa-secrets --namespace apic-control --from-file=publicKey=public_key --from-file=privateKey=private_key.pem --from-literal=password="" -o yaml
 ```
 
 Verify that the secrets are deployed in the `apic-control` namespace:
 
 ```
-$ kubectl get secrets -n apic-control
+kubectl get secrets -n apic-control
 NAME                  TYPE                                  DATA   AGE
 csa-secrets           Opaque                                3      29s
 default-token-f26bp   kubernetes.io/service-account-token   3      4m
@@ -181,27 +182,27 @@ After you have created the key pairs and secrets, deploy the Axway proprietary s
 1. To ensure that you have the latest Axway Helm charts, update your Helm repositories:
 
    ```
-   $ helm repo up
+   helm repo up
    Hang tight while we grab the latest from your chart repositories...
    ...Skip local chart repository
    ...Successfully got an update from the "axway" chart repository
    Update Complete. ⎈ Happy Helming!⎈
    ```
 
-1. Change to the directory where you unzipped the hybrid kit:
+2. Change to the directory where you unzipped the hybrid kit:
 
    ```
-   $ cd e4fd7216693f50360169492633ab0122/
+   cd e4fd7216693f50360169492633ab0122/
    ```
 
-1. Deploy Istio. This step can take several minutes to complete.
+3. Deploy Istio. This step can take several minutes to complete.
 
     Usage: `helm upgrade --install --namespace NAMESPACE_NAME RELEASE CHART`
 
     Example 1: Install istio-init
-   
+
     ```
-      $ helm upgrade --install --namespace istio-system istio axway/istio-init
+      helm upgrade --install --namespace istio-system istio axway/istio-init
       Release "istio-init" does not exist. Installing it now.
       NAME:   istio-init
       LAST DEPLOYED: Tue Mar  5 08:44:59 2019
@@ -242,7 +243,7 @@ After you have created the key pairs and secrets, deploy the Axway proprietary s
     Example 2: Install istio
 
     ```
-      $ helm upgrade --install --namespace istio-system istio axway/istio -f ./istioOverride.yaml
+      helm upgrade --install --namespace istio-system istio axway/istio -f ./istioOverride.yaml
       Release "istio" does not exist. Installing it now.
       NAME:   istio
       LAST DEPLOYED: Tue Mar  5 08:44:59 2019
@@ -252,22 +253,22 @@ After you have created the key pairs and secrets, deploy the Axway proprietary s
 
     This example uses the `istio` Helm chart from the `axway` Helm repository, with override values from the `istioOverride.yaml` Helm chart that you downloaded from AMPLIFY Central as part of the hybrid kit.
 
-1. Verify that Istio is deployed successfully:
+4. Verify that Istio is deployed successfully:
 
     ```
-    $ kubectl get services -n istio-system
+    kubectl get services -n istio-system
     ```
 
     The output of this command should list an domain edge gateway and a number of Istio services.
 
-1. Deploy the Axway mesh agents. This step can take several minutes to complete.
+5. Deploy the Axway mesh agents. This step can take several minutes to complete.
 
     Usage: `helm upgrade --install --namespace NAMESPACE_NAME RELEASE CHART -f /PATH/TO/OVERRIDE/VALUES [OPTIONS]`
 
     Example:
 
     ```
-    $ helm upgrade --install --namespace apic-control apic-hybrid axway/apicentral-hybrid -f ./hybridOverride.yaml --set observer.enabled=true --set observer.filebeat.sslVerification=none
+    helm upgrade --install --namespace apic-control apic-hybrid axway/apicentral-hybrid -f ./hybridOverride.yaml --set observer.enabled=true --set observer.filebeat.sslVerification=none
     Release "apic-hybrid" does not exist. Installing it now.
     NAME:   apic-hybrid
     LAST DEPLOYED: Tue Mar  5 10:57:27 2019
@@ -277,22 +278,22 @@ After you have created the key pairs and secrets, deploy the Axway proprietary s
 
     {{< alert title="Note" color="primary" >}}The `observer.enabled` and `observer.filebeat.sslVerification` options are required to enable collection of API usage and API traffic metrics from your environment. {{< /alert >}}
 
-1. Verify that the mesh agents are deployed in the `apic-control` namespace:
+6. Verify that the mesh agents are deployed in the `apic-control` namespace:
 
     ```
-    $ kubectl get services -n apic-control
+    kubectl get services -n apic-control
     ```
 
     The output of this command should list the mesh agent services.
-1. Verify that the list demo service is deployed in the `apic-demo` namespace:
-   
+7. Verify that the list demo service is deployed in the `apic-demo` namespace:
+
     ```
-    $ kubectl get services -n apic-demo
+    kubectl get services -n apic-demo
     ```
 
     The output of this command should list the demo list service.
 
-1. Verify that your environment is now connected in AMPLIFY Central UI:
+8. Verify that your environment is now connected in AMPLIFY Central UI:
 
     ![Connected environment in AMPLIFY Central](/Images/central/hybrid__env_connected.png)
 
@@ -305,8 +306,9 @@ The list demo service is now deployed in your hybrid environment. You can create
 You can test the API proxy in AMPLIFY Central UI or using a REST client. The following example uses `curl` to send a `GET` request to the `/list` endpoint:
 
 Example:
+
 ```
-$ curl -is -X GET 'http://kubernetes-cluster.example.com:8080/listapi/list'
+curl -is -X GET 'http://kubernetes-cluster.example.com:8080/listapi/list'
 HTTP/1.1 200 OK
 server: envoy
 request-id: c14a76d6-5ec6-4831-9650-e8a11258edbb

--- a/content/en/docs/central/backend_authn.md
+++ b/content/en/docs/central/backend_authn.md
@@ -10,8 +10,8 @@ description: Learn how to configure back-end authentication for an API.
 
 ## Before you start
 
-- You will need a user account for {{< variables/central_prod_name >}}
-- You will need an API which supports back-end authentication
+* You will need a user account for {{< variables/central_prod_name >}}
+* You will need an API which supports back-end authentication
 
 ## Objectives
 
@@ -35,8 +35,8 @@ On the **Policies** tab, change the back-end authentication policy to `HTTP Basi
 
 The credentials for the sample musical instruments API are:
 
-- user name/password: `admin`/`changeme`
-- user name/no password: `EtHJ0DUYiqv1l5hV1Ztg2XW7HfLlBZKk`
+* user name/password: `admin`/`changeme`
+* user name/no password: `EtHJ0DUYiqv1l5hV1Ztg2XW7HfLlBZKk`
 
 Watch the animation to learn how to do this in AMPLIFY Central UI.
 
@@ -48,7 +48,7 @@ Changing the back-end authentication policy (for example, from no authentication
 
 On the **Deployments** tab, deploy or update a runtime group with this revision of your API proxy.
 
-On the **Test Methods** tab, execute a method. It should return a `200 OK` result. This indicates a successful call of the API using HTTP basic as the back-end authentication. 
+On the **Test Methods** tab, execute a method. It should return a `200 OK` result. This indicates a successful call of the API using HTTP basic as the back-end authentication.
 
 If you execute a method and it returns a `401 Unauthorized` result, this indicates an unsuccessful call of the API (for example, due to invalid authentication credentials).
 

--- a/content/en/docs/central/build_hybrid_env.md
+++ b/content/en/docs/central/build_hybrid_env.md
@@ -6,15 +6,15 @@ date: 2019-07-30
 description: Learn how to build a basic Amazon EC2 private cloud hybrid environment and add the required tools to enable you to access and manage it remotely from a client system.
 ---
 
-*Estimated reading time: 3 minutes*
+*Estimated reading time*: 3 minutes
 
 {{< alert title="Public beta" color="warning" >}}This feature is currently in **public beta** and not yet available for production use.{{< /alert >}}
 
 ## Before you start
 
-- Read [AMPLIFY Central mesh governance overview](/docs/central/hybrid_overview).
-- You will need a basic knowledge of Amazon Web Services (AWS), Amazon EC2 instances, and associated tools.
-- You will need to be familiar with Kubernetes and Helm, including running Helm, kubectl, and kops commands.
+* Read [AMPLIFY Central mesh governance overview](/docs/central/hybrid_overview).
+* You will need a basic knowledge of Amazon Web Services (AWS), Amazon EC2 instances, and associated tools.
+* You will need to be familiar with Kubernetes and Helm, including running Helm, kubectl, and kops commands.
 
 ## Objectives
 
@@ -24,15 +24,15 @@ Learn how to build a basic Amazon EC2 private cloud hybrid environment and add t
 
 ## Minimum requirements
 
-- Amazon EC2 instance with Kubernetes and Helm:
-  - Kubernetes 1.11.7 or later recommended
-  - Helm 2.13 or later recommended
-- Public facing fully qualified domain name (FQDN) of the Amazon EC2 cluster
-- Client system (for example, Linux VM) with the following tools installed for accessing and managing your Amazon EC2 environment remotely:
-  - AWS CLI 1.16 recommended - Enables you to interact with AWS services from the command line. See the [AWS CLI installation documentation](https://docs.aws.amazon.com/cli/latest/userguide/li-chap-install.html).
-  - kubectl 1.13 recommended - Enables you to deploy and manage applications on Kubernetes from the command line. See the [kubectl installation documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-  - kops 1.11 recommended - Helps you create, destroy, upgrade and maintain Kubernetes clusters from the command line. See the [kops installation documentation](https://github.com/kubernetes/kops/blob/master/docs/install.md).
-  - Helm 2.13 or later recommended - Enables you to install the Axway proprietary service mesh layer later, and to export Helm charts. See the [Helm installation documentation](https://helm.sh/docs/using_helm/#installing-helm).
+* Amazon EC2 instance with Kubernetes and Helm:
+    * Kubernetes 1.11.7 or later recommended
+    * Helm 2.13 or later recommended
+* Public facing fully qualified domain name (FQDN) of the Amazon EC2 cluster
+* Client system (for example, Linux VM) with the following tools installed for accessing and managing your Amazon EC2 environment remotely:
+    * AWS CLI 1.16 recommended - Enables you to interact with AWS services from the command line. See the [AWS CLI installation documentation](https://docs.aws.amazon.com/cli/latest/userguide/li-chap-install.html).
+    * kubectl 1.13 recommended - Enables you to deploy and manage applications on Kubernetes from the command line. See the [kubectl installation documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+    * kops 1.11 recommended - Helps you create, destroy, upgrade and maintain Kubernetes clusters from the command line. See the [kops installation documentation](https://github.com/kubernetes/kops/blob/master/docs/install.md).
+    * Helm 2.13 or later recommended - Enables you to install the Axway proprietary service mesh layer later, and to export Helm charts. See the [Helm installation documentation](https://helm.sh/docs/using_helm/#installing-helm).
 
 ## Build an Amazon EC2 hybrid environment
 
@@ -41,7 +41,7 @@ Follow these guidelines to build a basic Amazon EC2 hybrid environment manually.
 ### Set up Amazon EC2
 
 1. To create an Amazon EC2 environment, follow the five steps in the [Amazon EC2 set up documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/get-set-up-for-amazon-ec2.html).
-1. To launch and connect to an Amazon EC2 instance, follow the first two steps in the [Amazon EC2 get started documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html). When launching the instance, choose a Linux AMI and an instance type of `t2.medium`.
+2. To launch and connect to an Amazon EC2 instance, follow the first two steps in the [Amazon EC2 get started documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html). When launching the instance, choose a Linux AMI and an instance type of `t2.medium`.
 
 ### Add Kubernetes to Amazon EC2
 
@@ -54,17 +54,17 @@ When the cluster is created, use kops to export the configuration from the Amazo
 Usage:
 
 ```
-$ kops export kubecfg --name CLUSTER_NAME --state STATE_STORAGE_LOCATION
+kops export kubecfg --name CLUSTER_NAME --state STATE_STORAGE_LOCATION
 ```
 
 Example:
 
 ```
-$ kops export kubecfg --name kubernetes-cluster.example.com --state s3://amazonaws.com
+kops export kubecfg --name kubernetes-cluster.example.com --state s3://amazonaws.com
 ```
 
-- `kubernetes-cluster.example.com` is the public FQDN (or name) of your cluster
-- `s3://amazonaws.com` is the Amazon S3 cloud storage bucket location defined when Kubernetes was added to your cluster
+* `kubernetes-cluster.example.com` is the public FQDN (or name) of your cluster
+* `s3://amazonaws.com` is the Amazon S3 cloud storage bucket location defined when Kubernetes was added to your cluster
 
 ### Configure Helm on Amazon EC2
 
@@ -73,28 +73,28 @@ Install Helm on your cluster and add the Axway public repository to Helm:
 1. To install the Helm server (Tiller) on the connected cluster:
 
     ```
-    $ helm init
+    helm init
     ```
 
-1. Verify the Helm version:
+2. Verify the Helm version:
 
     ```
-    $ helm version
+    helm version
     Client: &version.Version{SemVer:"v2.13.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a339489417b146b", GitTreeState:"clean"}
     Server: &version.Version{SemVer:"v2.13.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a339489417b146b", GitTreeState:"clean"}
     ```
 
-1. Add the Axway public Helm repository to your installation:
+3. Add the Axway public Helm repository to your installation:
 
     ```
-    $ helm repo add axway https://charts.axway.com/charts
+    helm repo add axway https://charts.axway.com/charts
     "axway" has been added to your repositories
     ```
 
-1. Verify that the Axway public repository has been added:
+4. Verify that the Axway public repository has been added:
 
     ```
-    $ helm repo list
+    helm repo list
     NAME            URL
     stable          https://kubernetes-charts.storage.googleapis.com
     local           http://127.0.0.1:8879/charts
@@ -108,7 +108,7 @@ Use the following commands to validate your environment using kubectl or kops.
 kubectl:
 
 ```
-    $ kubectl get nodes
+    kubectl get nodes
     NAME                                         STATUS   ROLES    AGE   VERSION
     ip-172-0-33-242.us-west-2.compute.internal   Ready    node     25d   v1.10.12
     ip-172-0-35-225.us-west-2.compute.internal   Ready    node     25d   v1.10.12
@@ -119,7 +119,7 @@ kubectl:
 kops:
 
 ```
-$ kops validate cluster
+kops validate cluster
 Using cluster from kubectl context: kubernetes-cluster.example.com
 ...
 Your cluster kubernetes-cluster.example.com is ready

--- a/content/en/docs/central/catalog.md
+++ b/content/en/docs/central/catalog.md
@@ -6,7 +6,7 @@ date: 2019-12-16
 description: Normalize discovery for APIs from multiple gateways, classify your services to support multiple audiences (partners, IT, business), control consumer subscription to access your APIs, and extend your APIs to be reused in other integration ﬂows.
 ---
 
-*Estimated reading time: 5 minutes*
+*Estimated reading time*: 5 minutes
 
 ## AMPLIFY Catalog Overview
 

--- a/content/en/docs/central/cli_proxy_flow.md
+++ b/content/en/docs/central/cli_proxy_flow.md
@@ -5,7 +5,8 @@ weight: 6
 date: 2019-07-30T00:00:00.000Z
 description: Learn how your DevOps service can use AMPLIFY CLI to manage your API proxies.
 ---
-_Estimated reading time_: 5 minutes
+
+*Estimated reading time*_*: 5 minutes
 
 ## Before you start
 

--- a/content/en/docs/central/fundamental_concepts.md
+++ b/content/en/docs/central/fundamental_concepts.md
@@ -6,7 +6,7 @@ date: 2019-07-30
 description: Learn the fundamental concepts you will encounter in AMPLIFY Central.
 ---
 
-*Estimated reading time: 1 minute*
+*Estimated reading time*: 1 minute
 
 ## API and API proxy
 
@@ -20,9 +20,9 @@ An API is an interface to a service, that enables app developers to interact wit
 
 An API is clearly defined by way of its endpoints, request parameters, and responses. This makes it easy for app developers to use the API, as the API specification (for example, Open API or Swagger) tells them:
 
-- What requests they can send and to what address
-- What the supported request parameters are
-- What responses they can expect
+* What requests they can send and to what address
+* What the supported request parameters are
+* What responses they can expect
 
 An API implies a *contract*, which provides app developers with an assurance that the API will change in a predictable manner over time, meaning that their app will continue to work with future changes to the API.
 
@@ -34,9 +34,9 @@ In AMPLIFY Central, you create an API proxy to represent your back-end API to yo
 
 Managing your API in AMPLIFY Central by way of an API proxy offers the following benefits:
 
-- You can change the implementation of the back-end service without impacting app developers as they continue to call the API proxy.
-- You can apply policies to the API proxy to manage or secure how client apps use your API.
-- You can analyze the usage of your APIs by client apps, and identify and analyze failed transactions, as all traffic that flows through an API proxy is monitored and recorded.
+* You can change the implementation of the back-end service without impacting app developers as they continue to call the API proxy.
+* You can apply policies to the API proxy to manage or secure how client apps use your API.
+* You can analyze the usage of your APIs by client apps, and identify and analyze failed transactions, as all traffic that flows through an API proxy is monitored and recorded.
 
 ## Roles and teams
 

--- a/content/en/docs/central/hybrid_overview.md
+++ b/content/en/docs/central/hybrid_overview.md
@@ -6,7 +6,7 @@ date: 2019-07-30
 description: Understand what mesh governance is, what a hybrid environment is, and how you can manage the APIs and microservices in a hybrid environment from AMPLIFY Central.
 ---
 
-*Estimated reading time: 3 minutes*
+*Estimated reading time*: 3 minutes
 
 {{< alert title="Public beta" color="warning" >}}This feature is currently in **public beta** and not yet available for production use.{{< /alert >}}
 
@@ -16,10 +16,10 @@ AMPLIFY Central *mesh governance* enables you to govern and manage your APIs, pu
 
 AMPLIFY Central mesh governance provides the following key capabilities:
 
-- Manage your public and private services, wherever they are located
-- Add a service mesh layer to your on-premise or private cloud hybrid environments
-- Manage your mesh policies along with their related services and associated APIs
-- Connect and manage those hybrid environments and their service meshes
+* Manage your public and private services, wherever they are located
+* Add a service mesh layer to your on-premise or private cloud hybrid environments
+* Manage your mesh policies along with their related services and associated APIs
+* Connect and manage those hybrid environments and their service meshes
 
 The mesh governance capability of AMPLIFY Central currently supports adding a service mesh layer to an Amazon EC2 private cloud environment. This will be extended in the future to include other private cloud environments (for example, Microsoft Azure or Red Hat OpenShift).
 
@@ -39,8 +39,8 @@ The data plane is where API transactions and related user microservices are host
 
 The data plane in an AMPLIFY Central hybrid environment is logically split into a service mesh data plane and control plane.
 
-- Service mesh data plane – Consists of a set of intelligent proxies (Envoy) deployed as sidecars on your microservices.
-- Service mesh control plane – Axway mesh agents manage Istio, which in turn manages and configures the proxies to route traffic. Istio also controls how Envoy exposes proxies and routes traffic inside the mesh.
+* Service mesh data plane – Consists of a set of intelligent proxies (Envoy) deployed as sidecars on your microservices.
+* Service mesh control plane – Axway mesh agents manage Istio, which in turn manages and configures the proxies to route traffic. Istio also controls how Envoy exposes proxies and routes traffic inside the mesh.
 
 For more information on Istio and Envoy, see the [Istio documentation](https://istio.io/docs/).
 

--- a/content/en/docs/central/overview.md
+++ b/content/en/docs/central/overview.md
@@ -6,7 +6,7 @@ date: 2019-07-30
 description: Deploy and secure your services in any environment (for example, cloud, on-premise, and so on) and govern your APIs through a central platform that allows you to integrate your services safely and easily with both internal and external consumers.
 ---
 
-*Estimated reading time: 2 minutes*
+*Estimated reading time*: 2 minutes
 
 AMPLIFY Central is a governance platform that enables a self-service centralized API and microservices management across virtualized networks in any cloud platform or in a private datacenter. Its core features provide API security, monitoring, and traffic management independent of the implementation of the API.
 
@@ -46,9 +46,9 @@ You can create API proxies and deploy them to runtime groups using the AMPLIFY C
 
 DevOps can be defined as a combination of people, processes, and technology that increases your organization's ability to quickly deliver quality services to your customers.
 
-- People: Developers, operations, product owners, testers, infrastructure engineers, and so on, all work together collaboratively as a team to build and deliver the service.
-- Process: Continuous improvement of the process to deliver a quality service is key.
-- Technology: Tools that automate the manual processes and integrate with other tools to make it easier and faster to develop, package, test, release, and deploy the service.
+* **People**: Developers, operations, product owners, testers, infrastructure engineers, and so on, all work together collaboratively as a team to build and deliver the service.
+* **Process**: Continuous improvement of the process to deliver a quality service is key.
+* **Technology**: Tools that automate the manual processes and integrate with other tools to make it easier and faster to develop, package, test, release, and deploy the service.
 
 ### AMPLIFY Central DevOps approach
 
@@ -62,11 +62,11 @@ AMPLIFY Central is a CI/CD native solution that you can easily snap in to your e
 
 The AMPLIFY Central DevOps API is a DevOps-friendly REST API that you can use to create, update, deploy, and promote API proxies to AMPLIFY Central runtimes. It provides the following DevOps-friendly features:
 
-- The APIs accept a YAML configuration file which represents the desired state of the API proxy.
-  - YAML format is human-readable, easily diffed, and maintainable.
-  - YAML configuration file can be versioned along with the code for the service in a version control system, such as Git.
-- The APIs are coarse-grained, avoiding the need for complex ordered API invocations to multiple fine-grained APIs.
-- The APIs use an update or insert (*upsert*) strategy. If the API proxy already exists it is updated, otherwise it is created.
+* The APIs accept a YAML configuration file which represents the desired state of the API proxy.
+    * YAML format is human-readable, easily diffed, and maintainable.
+    * YAML configuration file can be versioned along with the code for the service in a version control system, such as Git.
+* The APIs are coarse-grained, avoiding the need for complex ordered API invocations to multiple fine-grained APIs.
+* The APIs use an update or insert (*upsert*) strategy. If the API proxy already exists it is updated, otherwise it is created.
 
 Visit our [API documentation](https://d-api.docs.stoplight.io/).
 
@@ -82,12 +82,12 @@ The following shows an example DevOps flow to create, deploy, and promote an API
 2. Jenkins build triggers and checks out the latest code and YAML from Git.
 3. Jenkins calls AMPLIFY CLI command `amplify auth login` to authenticate to AMPLIFY platform and obtain an access token.
 4. Jenkins calls AMPLIFY CLI command `amplify apic create` to create or update the API proxy for this service.
-    - CLI calls the DevOps API `POST /proxies` to create the API proxy in AMPLIFY Central. See [Create proxy API reference](https://d-api.docs.stoplight.io/new-subpage/devops-api/create-proxy).
+    * CLI calls the DevOps API `POST /proxies` to create the API proxy in AMPLIFY Central. See [Create proxy API reference](https://d-api.docs.stoplight.io/new-subpage/devops-api/create-proxy).
 5. Jenkins calls AMPLIFY CLI command `amplify apic promote` to deploy the API proxy to the test runtime.
-    - CLI calls the DevOps API `POST /promote` to deploy the API proxy on the test runtime. See [Promote proxy API reference](https://d-api.docs.stoplight.io/new-subpage/devops-api/promote-proxy).
+    * CLI calls the DevOps API `POST /promote` to deploy the API proxy on the test runtime. See [Promote proxy API reference](https://d-api.docs.stoplight.io/new-subpage/devops-api/promote-proxy).
 6. Automated tests are run on the AMPLIFY Central test runtime.
 7. Jenkins calls AMPLIFY CLI command `amplify apic promote` to promote the API proxy from the test runtime to the production runtime.
-    - CLI calls the DevOps API `POST /promote` to deploy the API proxy on the production runtime.
+    * CLI calls the DevOps API `POST /promote` to deploy the API proxy on the production runtime.
 
 ## Traffic management
 

--- a/content/en/docs/central/proxy_rate_limit.md
+++ b/content/en/docs/central/proxy_rate_limit.md
@@ -34,8 +34,8 @@ AMPLIFY Central provides rate limiting around the API Proxy activity. You can se
 
 AMPLIFY Central allows for two levels of enforcement for rate limiting:  
 
-* At the proxy level, rate limiting affects all API transactions regardless of the consuming application. 
-* At the proxy and application level, rate limiting affects all API transactions originating with a specific application. 
+* At the proxy level, rate limiting affects all API transactions regardless of the consuming application.
+* At the proxy and application level, rate limiting affects all API transactions originating with a specific application.
 
 You can enforce one or both levels together.
 
@@ -47,7 +47,7 @@ To begin, [register an api proxy](/docs/central/quickstart/#register-an-api).
 
 1. Navigate to the **API Proxies** tab.
 2. Click the API proxy name to open the API proxy details page.
-3. On the **Policies** tab, edit the rate limit policy under the **Request to backend** section. 
+3. On the **Policies** tab, edit the rate limit policy under the **Request to backend** section.
 4. Enter the desired TPS and click the checkbox to save the configuration.
 
 ![Enter the desired TPS](/Images/central/proxy_rate_limit_box.png)
@@ -56,7 +56,7 @@ A new revision with the desired rate limit configuration is created. You must de
 
 ### Test the rate limit configuration
 
-You can test the rate limit configuration 
+You can test the rate limit configuration.
 
 #### Simple test with docker and curl
 
@@ -69,7 +69,7 @@ docker run curlimages/curl:7.66.0 -s -o /dev/null -w "%{url_effective}:%{http_co
 Example run for the sample API with a rate limit of 2 TPS:
 
 ```
-$ docker run curlimages/curl:7.66.0 -s -o /dev/null -w "%{url_effective}:%{http_code}\n" -Z "https://test-e4f77cd969cdaf3a0169ce16c8320000.apicentral.axwayamplify.com/music/v2/instruments#[1-5]"
+docker run curlimages/curl:7.66.0 -s -o /dev/null -w "%{url_effective}:%{http_code}\n" -Z "https://test-e4f77cd969cdaf3a0169ce16c8320000.apicentral.axwayamplify.com/music/v2/instruments#[1-5]"
 https://test-e4f77cd969cdaf3a0169ce16c8320000.apicentral.axwayamplify.com/music/v2/instruments#1:429
 https://test-e4f77cd969cdaf3a0169ce16c8320000.apicentral.axwayamplify.com/music/v2/instruments#3:429
 https://test-e4f77cd969cdaf3a0169ce16c8320000.apicentral.axwayamplify.com/music/v2/instruments#2:429
@@ -107,7 +107,7 @@ export default function() {
 }
 ```
 
-Using the dockerized version of K6, run a test mimicking 20 users sending 20 TPS to your API proxy for 30 seconds. 
+Using the dockerized version of K6, run a test mimicking 20 users sending 20 TPS to your API proxy for 30 seconds.
 
 Replace `<your_url_here>` with an endpoint of your proxy.
 
@@ -181,7 +181,6 @@ proxy:
 ```
 
 The `perProxy` field specifies the desired Transactions Per Second (TPS) limit for your API.
-
 
 Create the API proxy:
 
@@ -267,7 +266,7 @@ You can rate limit the API calls at variable interval instead of fixed 1 second 
 Under `perProxy` or `perProxyAndApp` you can specify two configurations:
 
 * `limit` value defines number of API calls that needs to be rate limited.
-* `interval` value defines at what interval, API calls needs to be rate limited at. 
+* `interval` value defines at what interval, API calls needs to be rate limited at.
   
 The field `interval` must follow the format `PT[n]H[n]M[n]S`, supported by the ISO_8601 standard.
 
@@ -303,8 +302,6 @@ proxy:
     team:
         name: 'Default Team'
 ```
-
-
 
 ### Disable the rate limit for an application consuming your API
 

--- a/content/en/docs/central/quickstart.md
+++ b/content/en/docs/central/quickstart.md
@@ -6,22 +6,22 @@ date: 2019-07-30
 description: Learn how to register your first API in AMPLIFY Central.
 ---
 
-*Estimated reading time: 2 minutes*
+*Estimated reading time*: 2 minutes
 
 ## Before you start
 
-- Read [AMPLIFY Central overview](/docs/central/overview)
-- Read [Understand AMPLIFY Central concepts](/docs/central/fundamental_concepts)
-- Sign up for a free trial of AMPLIFY Central at [AMPLIFY platform](https://platform.axway.com/)
+* Read [AMPLIFY Central overview](/docs/central/overview)
+* Read [Understand AMPLIFY Central concepts](/docs/central/fundamental_concepts)
+* Sign up for a free trial of AMPLIFY Central at [AMPLIFY platform](https://platform.axway.com/)
 
 ## Objectives
 
 Learn how to register your first API in AMPLIFY Central.
 
-- Register an API as an API proxy and deploy it to a runtime group
-- Secure the API with a client authentication policy
-- Monitor the API usage and traffic
-- Publish the API endpoints to AMPLIFY Catalog
+* Register an API as an API proxy and deploy it to a runtime group
+* Secure the API with a client authentication policy
+* Monitor the API usage and traffic
+* Publish the API endpoints to AMPLIFY Catalog
 
 ## Register an API
 
@@ -39,9 +39,9 @@ Watch this video to learn how to secure your API with a client authentication po
 
 To monitor API usage and troubleshoot API traffic in AMPLIFY Central UI, click **API Observer** in the left navigation bar.
 
-- Click **API Usage** to see an aggregated view of the recent usage of your API. This view is useful for monitoring traffic patterns, and successes or failures over time.
+* Click **API Usage** to see an aggregated view of the recent usage of your API. This view is useful for monitoring traffic patterns, and successes or failures over time.
   ![Example of API usage](/Images/central/apiobserver_usage.png)
-- Click **API Traffic** to view the traffic information. This view is useful for finding and troubleshooting any failed transactions.
+* Click **API Traffic** to view the traffic information. This view is useful for finding and troubleshooting any failed transactions.
   ![Example of API traffic](/Images/central/apiobserver_traffic.png)
 
 ## Publish API to AMPLIFY Catalog

--- a/content/en/docs/central/secure_api_jwt.md
+++ b/content/en/docs/central/secure_api_jwt.md
@@ -6,13 +6,13 @@ date: 2019-07-30
 description: Learn how to secure your API using a JWT token.
 ---
 
-*Estimated reading time: 6 minutes*
+*Estimated reading time*: 6 minutes
 
 ## Before you start
 
-- You will need a basic understanding of JWT ([RFC 7523](https://tools.ietf.org/html/rfc7523))
-- You will need a user account for AMPLIFY Central
-- Import your API as an API proxy in AMPLIFY Central (see [Register an API](/docs/central/quickstart/#register-an-api))
+* You will need a basic understanding of JWT ([RFC 7523](https://tools.ietf.org/html/rfc7523))
+* You will need a user account for AMPLIFY Central
+* Import your API as an API proxy in AMPLIFY Central (see [Register an API](/docs/central/quickstart/#register-an-api))
 
 ## Objectives
 
@@ -38,9 +38,9 @@ To be able to test your API, create an app to manage client access to your API:
 2. On the **Identity Profiles** tab, in the **JWT Keys** section, add a new JWT key.
 3. Enter a name for the key.
 4. Paste your JWT public key into the **JWT Key** field.
-    - You must create your own JWT token to secure an API with JWT.
-    - The JWT token must be signed using the `RS256` algorithm.
-    - There are many services that allow you to create a JWT token. See [Create a JWT token](#create-a-jwt-token) for some examples, however, you can choose whichever service is best suited for your organization. These services provide you with both a public key and a private key. The public key is needed for this step.
+    * You must create your own JWT token to secure an API with JWT.
+    * The JWT token must be signed using the `RS256` algorithm.
+    * There are many services that allow you to create a JWT token. See [Create a JWT token](#create-a-jwt-token) for some examples, however, you can choose whichever service is best suited for your organization. These services provide you with both a public key and a private key. The public key is needed for this step.
 5. On the **APIs** tab, add a new API.
 6. Select your API proxy with JWT authentication, and select the runtime group you deployed it to.
 
@@ -64,9 +64,9 @@ Watch the animation to learn how to do this in AMPLIFY Central UI.
 
 There are many libraries and methods for creating signed JWT tokens. The first step is to generate an RSA key pair. This section demonstrates generating the key pair and provides examples of the following signing methods:
 
-- Bash script using openssl and jq
-- Go binary
-- jwt.io
+* Bash script using openssl and jq
+* Go binary
+* jwt.io
 
 ### Generate a key pair
 
@@ -193,9 +193,9 @@ Copy the sample above to a script called `signPrvtKey.sh` and execute it with:
 
 This example uses [jwt.io](https://jwt.io/) to create a JWT token:
 
-- Use the default public key from jwt.io as the **JWT Key** for your app in AMPLIFY Central or create a public key as detailed in [Generate a key pair](#generate-a-key-pair).
-- To create the JWT token, you need the **Application ID** and **JWT Key ID** from the API proxy in AMPLIFY Central.
-- Use the generated JWT token from jwt.io as the **JWT Token** to test your API in AMPLIFY Central.
+* Use the default public key from jwt.io as the **JWT Key** for your app in AMPLIFY Central or create a public key as detailed in [Generate a key pair](#generate-a-key-pair).
+* To create the JWT token, you need the **Application ID** and **JWT Key ID** from the API proxy in AMPLIFY Central.
+* Use the generated JWT token from jwt.io as the **JWT Token** to test your API in AMPLIFY Central.
 
 {{< alert title="Caution" color="warning" >}} This method is for testing only as it requires you to share your private key with a third party website.{{< /alert >}}
 
@@ -215,8 +215,8 @@ To create a JWT token on jwt.io:
     ```
 
 5. Edit the Payload section.
-    - Copy and paste the **Application ID** from the **Test Methods** tab of the API proxy in AMPLIFY Central as the `sub`, `aud`, and `iss` fields. 
-    - For the `iat` and `exp` fields, enter epoch values for when the token was issued at and when it expires. For example:
+    * Copy and paste the **Application ID** from the **Test Methods** tab of the API proxy in AMPLIFY Central as the `sub`, `aud`, and `iss` fields.
+    * For the `iat` and `exp` fields, enter epoch values for when the token was issued at and when it expires. For example:
 
         ```
         {


### PR DESCRIPTION
I've fixed a lot of markdown lint errors on Central, Cassandra, APIP-HA, APIP Install and Admin docs. In order to fix the issue in some old pages, I had to restructure the content (convert tables to text).