### PR TITLE
Added swagger promote link

### DIFF
--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -11,6 +11,7 @@ When APIs have been registered in API Manager, you can promote them directly bet
 The following approaches to promoting managed APIs are also available:
 
 * Use the `apimanager-promote` script to automatically promote APIs between environments with zero downtime for DevOps.
+* Use the `swagger-promote` tool to follow the APIs as Code approach. [Learn more](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote)
 * Use a promotion policy that you have configured in Policy Studio to automate promotion between environments.
 * When APIs have been developed using Policy Studio, you can also promote them between environments using the API Gateway mechanism for promotion and deployment of standard API Gateway configuration.
 

--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -8,12 +8,13 @@
 
 When APIs have been registered in API Manager, you can promote them directly between environments using the API Manager export and import mechanism. This exports registered APIs in JSON format, which you can then import into API Manager as required.
 
-The following approaches to promoting managed APIs are also available:
+Alternatively, you can use one of these approaches:
 
 * Use the `apimanager-promote` script to automatically promote APIs between environments with zero downtime for DevOps.
-* Use the `swagger-promote` tool to follow the APIs as Code approach. Store your API-Definition (Swagger/WSDL) plus a Meta-Data config-file in your version control system and a CI/CD-Pipeline replicates it into API-Manager stage you want. [Learn more](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote)
 * Use a promotion policy that you have configured in Policy Studio to automate promotion between environments.
 * When APIs have been developed using Policy Studio, you can also promote them between environments using the API Gateway mechanism for promotion and deployment of standard API Gateway configuration.
+
+{{< alert title="Tip" color="primary" >}}Another alternative is to use the `swagger-promote` tool to follow an APIs as code approach. Store your API definition (Swagger or WSDL) plus a meta data configuration file in your version control system, and a CI/CD pipeline replicates it into API Manager in the state you want. For more details, go to [`swagger-promote` tool on GitHub](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote){{< /alert >}}
 
 ## Promote registered APIs with zero downtime using a script
 

--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -11,7 +11,7 @@ When APIs have been registered in API Manager, you can promote them directly bet
 The following approaches to promoting managed APIs are also available:
 
 * Use the `apimanager-promote` script to automatically promote APIs between environments with zero downtime for DevOps.
-* Use the `swagger-promote` tool to follow the APIs as Code approach. [Learn more](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote)
+* Use the `swagger-promote` tool to follow the APIs as Code approach. Store your API-Definition (Swagger/WSDL) plus a Meta-Data config-file in your version control system and a CI/CD-Pipeline replicates it into API-Manager stage you want. [Learn more](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote)
 * Use a promotion policy that you have configured in Policy Studio to automate promotion between environments.
 * When APIs have been developed using Policy Studio, you can also promote them between environments using the API Gateway mechanism for promotion and deployment of standard API Gateway configuration.
 

--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -14,7 +14,7 @@ Alternatively, you can use one of these approaches:
 * Use a promotion policy that you have configured in Policy Studio to automate promotion between environments.
 * When APIs have been developed using Policy Studio, you can also promote them between environments using the API Gateway mechanism for promotion and deployment of standard API Gateway configuration.
 
-{{< alert title="Tip" color="primary" >}}Another alternative is to use the `swagger-promote` tool to follow an APIs as code approach. Store your API definition (Swagger or WSDL) plus a meta data configuration file in your version control system, and a CI/CD pipeline replicates it into API Manager in the state you want. For more details, go to [`swagger-promote` tool on GitHub](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote){{< /alert >}}
+{{< alert title="Tip" color="primary" >}}Another alternative is to use the `swagger-promote` tool to follow an APIs as code approach. Store your API definition (Swagger or WSDL) plus a meta data configuration file in your version control system, and a CI/CD pipeline replicates it into API Manager in the state you want. For details, go to [`swagger-promote` tool on GitHub](https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote).{{< /alert >}}
 
 ## Promote registered APIs with zero downtime using a script
 


### PR DESCRIPTION
Swagger-Promote is a great way to automate the API-Manager. It's already successfully used by a lot customers and so we should make it part of the documentation, so that all customer know about it.

@maherb4, perhaps you can confirm if this is okay for you.