### PR TITLE
Fix the issue with links on page going to master instead of preview branch

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://axway-open-docs.netlify.com/"
 title = "Axway-Open-Docs"
 
 enableRobotsTXT = true

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://axway-open-docs.netlify.com/"
+baseURL = "/"
 title = "Axway-Open-Docs"
 
 enableRobotsTXT = true

--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-# if removed the site will not build!
+# if removed the site will not build!!
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
 # Highlighting config

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,18 @@
+# Hugo build configuration for Netlify 
+# (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
+
+# Default build settings
+[build]
+  publish = "public"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
+
+# "production" environment specific build settings
 [build.environment]
   HUGO_VERSION = "0.55.6"
+
+[context.production.environment]
+  HUGO_ENV = "production"
+  HUGO_ENABLEGITINFO = "true"
+
+[context.deploy-preview]
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo -b $DEPLOY_PRIME_URL"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,16 +3,15 @@
 
 # Default build settings
 [build]
-  publish = "public"
-  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
+publish = "public"
+command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
 
 # "production" environment specific build settings
 [build.environment]
-  HUGO_VERSION = "0.55.6"
+HUGO_VERSION = "0.55.6"
 
 [context.production.environment]
-  HUGO_ENV = "production"
-  HUGO_ENABLEGITINFO = "true"
+HUGO_ENV = "production"
 
 [context.deploy-preview]
-  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo -b $DEPLOY_PRIME_URL"
+command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
- Change the build command in netlify.toml to use the Netlify env variable $DEPLOY_PRIME_URL for deploy previews (as suggested in https://discourse.gohugo.io/t/correct-baseurl-on-netlify-previews/10429)
- Tested that the links in the page body work correctly on deploy previews
- Tested that the links to CMS and Contrib guidelines in right nav work correctly on deploy preview
- Tested that the links in left nav and cross-refs in the page body continue to work as before

(A future improvement would be to change the code that's used to build the CMS button and contrib guidelines link in right nav as it's not best practice from what I've read. I'll open a new issue for this.)

fixes #214 