### PR TITLE
Add a simple codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,86 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @global-owner1 @global-owner2
+
+# Global reviewers for this project
+*       @alexearnshaw @andreamussap
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+#*.js @js-owner
+
+# Config files
+*.html @alexearnshaw
+*.js    @alexearnshaw
+*.toml @alexearnshaw
+*.yml @alexearnshaw
+*.json @alexearnshaw
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+#*.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+#/build/logs/ @doctocat
+
+# Theme and CMS config files
+/layouts/ @alexearnshaw
+/static/admin/ @alexearnshaw
+
+# Documentation files for AMPCentral
+/content/en/docs/central/ @andreamussap @markbice
+
+# Documentation files for APIM
+/content/en/docs/apigtw_devguide/ @alexearnshaw
+/content/en/docs/apigtw_devops/ @andreamussap
+/content/en/docs/apigtw_kerberos/ @alexearnshaw
+/content/en/docs/apim_administration/apigtw_admin/ @alexearnshaw
+/content/en/docs/apim_administration/apimgr_admin/ @alexearnshaw
+/content/en/docs/apim_administration/apiportal_admin/ @andreamussap
+/content/en/docs/apim_installation/apigtw_install/ @alexearnshaw
+/content/en/docs/apim_installation/apigw_containers/ @alexearnshaw
+/content/en/docs/apim_installation/apigw_upgrade/ @alexearnshaw
+/content/en/docs/apim_installation/apiportal_docker/ @andreamussap
+/content/en/docs/apim_installation/apiportal_install/ @andreamussap
+/content/en/docs/apim_policydev/apigw_kps/ @andreamussap
+/content/en/docs/apim_policydev/apigw_oauth/ @alexearnshaw
+/content/en/docs/apim_policydev/apigw_polref/ @andreamussap
+/content/en/docs/apim_reference/ @andreamussap
+/content/en/docs/apim_relnotes/apigtw_releasenotes/ @alexearnshaw
+/content/en/docs/apim_relnotes/apimng_releasenotes/ @andreamussap
+/content/en/docs/apim_relnotes/apiportal_releasenotes/ @andreamussap
+/content/en/docs/apimanager_analytics/ @andreamussap
+/content/en/docs/apimanager_capacityguide/ @alexearnshaw
+/content/en/docs/apimgmt_multi_dc/ @andreamussap
+/content/en/docs/apimgmt_security/ @alexearnshaw
+/content/en/docs/apimgr_concepts/ @alexearnshaw
+/content/en/docs/apiportal_ha/ @andreamussap
+/content/en/docs/cass_admin/ @andreamussap
+/content/en/docs/glossary/ @andreamussap
+
+# Documentation guidelines and processes
+/content/en/docs/contribution_guidelines/ @alexearnshaw
+
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+#docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+#apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+#/docs/ @doctocat


### PR DESCRIPTION
Adding this file automates adding reviewers to all new pull requests. Whoever is assigned to the files or directories where the files are in the codeowners file is automatically requested as a reviewer.

At the moment it assigns:
- both tech writers as default owners for all files (both of us will be requested as reviewers if there is not a more specific rule)
- 1 tech writer to each area of doc. A review from this writer is mandatory and the PR cannot be merged without it.
- 1 SME (Mark) to the AMPLIFY Central doc (as a test). In the future we can extend this to include one or more SMEs (PO/PM or developer) to every area of doc. The SME review is not mandatory it's just a heads up for them to know the doc is changing and review if they want to.

Proposed change to the way of working:
- A tech writer reviewer is automatically be assigned to each new PR and that TW is then responsible for everything on that PR (triaging, reviewing, merging, pushing to prod, etc). 
- The TW can triage the issue straight away or at their convenience (but within 1 working day). 
- The TW should only set themselves as the **Assignee** when they are actively working on the issue.