### PR TITLE
Fix parameter 'closeComment' indentation in stale.yml file

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -39,8 +39,8 @@ markComment: >
 #   Your comment here.
 
 # Comment to post when closing a stale Issue or Pull Request.
- closeComment: >
-   This issue has been automatically closed due to inactivity.
+closeComment: >
+  This issue has been automatically closed due to inactivity.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
Relates to #268 
Tests #245 

@alexearnshaw  I've noticed that the indentation of one parameter was wrong so I fixed it, then tested the yml file at http://www.yamllint.com/ to validate the file. 