### PR TITLE
Set CMS to autoupdate

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -9,6 +9,6 @@
 
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@2.9.8-beta.4/dist/netlify-cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I wasn't able to successfully test this on a fork so am going to try testing on the preview.

Update - I can confirm that the forking problem is fixed. My fork is from before PR #288 was merged yet the CMS shows that change (from master as it should) and when I edit that topic (see test PR #311) the diff shows the changes between master and the CMS edit (not my fork as before)

Update - The latest version has various image issues compared to the current beta version we're using.
- Images are **completely removed from the diff** (see test PR #305)! Can't understand how/why this is happening and it doesn't seem to happen for all topics, e.g. test PR #309 images are not removed.
- Broken image links are shown in the CMS preview pane if the images were not uploaded via CMS. However these are not removed in the diff (see test PR #309 )

Conclusion:
We have to wait to update until  the image issues are fixed.

fixes #271 