### PR TITLE
Added documentation how to create a Custom-SAML-Assertion

### DIFF
--- a/content/en/docs/apim_policydev/apigw_polref/attributes_manipulate.md
+++ b/content/en/docs/apim_policydev/apigw_polref/attributes_manipulate.md
@@ -276,9 +276,9 @@ message attribute name):
 
 ## Insert SAML attribute assertion filter
 
-A Security Assertion Markup Language (SAML) attribute assertion contains information about a user in the form of a series of attributes. Having collated a certain amount of information about a user, the API Gateway can generate a SAML attribute assertion, and insert it into the downstream message.
+A Security Assertion Markup Language (SAML) attribute assertion contains information about a user in the form of a series of attributes. Having collated a certain amount of information about a user, the API Gateway can generate a SAML attribute assertion, and insert it into the downstream message. A *SAML Attribute* is generated for each entry in the `attribute.lookup.list` attribute. 
 
-A *SAML Attribute* (see example below) is generated for each entry in the `attribute.lookup.list` attribute. Other filters from the Attributes filter group can be used to insert user attributes into the `attribute.lookup.list` attribute or you use the Javascript filter to create the attribute `attribute.lookup.list` using custom attributes you want. See [here](https://github.com/Axway-API-Management-Plus/scripting-examples/blob/master/create-saml-assertion/README.md) for an example.
+You can also use other filters from the Attributes filter group to insert user attributes into the `attribute.lookup.list`, or you can use the Javascript filter to dynamically create the `attribute.lookup.list` using custom attributes. For more information, see [Create SAML assertion using the API Gateway](https://github.com/Axway-API-Management-Plus/scripting-examples/blob/master/create-saml-assertion/README.md).
 
 You can refer to the following example of a SAML attribute assertion when configuring this filter:
 

--- a/content/en/docs/apim_policydev/apigw_polref/attributes_manipulate.md
+++ b/content/en/docs/apim_policydev/apigw_polref/attributes_manipulate.md
@@ -278,8 +278,7 @@ message attribute name):
 
 A Security Assertion Markup Language (SAML) attribute assertion contains information about a user in the form of a series of attributes. Having collated a certain amount of information about a user, the API Gateway can generate a SAML attribute assertion, and insert it into the downstream message.
 
-A *SAML Attribute* (see example below) is generated for each entry in the `attribute.lookup.list` attribute. Other filters from the Attributes filter group can be used to insert user attributes into the `attribute.lookup.list`
-attribute.
+A *SAML Attribute* (see example below) is generated for each entry in the `attribute.lookup.list` attribute. Other filters from the Attributes filter group can be used to insert user attributes into the `attribute.lookup.list` attribute or you use the Javascript filter to create the attribute `attribute.lookup.list` using custom attributes you want. See [here](https://github.com/Axway-API-Management-Plus/scripting-examples/blob/master/create-saml-assertion/README.md) for an example.
 
 You can refer to the following example of a SAML attribute assertion when configuring this filter:
 


### PR DESCRIPTION
To create a SAML-Assertion, only the filters we provide in the section Attributes can be used, but this is sometimes not flexible enough. 

For instance, when a User has been authenticated using an OAuth-Token, a new SAML-Assertion should be created on the fly. This is a quite complicated task for a very common scenario and we should help our customers by providing an example for it. 

BTW: My plan is to add more examples into the same GitHub repository and when appropriate link it into our documentation. I hope that is okay. I would like to share knowledge and avoid everybody is creating it's own implementation. Another example I'll tackle is this one: 
https://community.axway.com/s/question/0D52X00008NqmDPSAZ/signing-a-custom-jwt-with-rsa256