### PR TITLE
Revise update terminology

### DIFF
--- a/content/en/docs/apim_administration/apigtw_admin/admin_non_root.md
+++ b/content/en/docs/apim_administration/apigtw_admin/admin_non_root.md
@@ -119,7 +119,7 @@ getcap /opt/Axway-7.7/apigateway/platform/bin/vshell
 /opt/Axway-7.7/apigateway/platform/bin/vshell = cap_net_bind_service+ep
 ```
 
-If you set this capability, you must remove it again before applying a service pack or uninstalling, as it results in the product binaries being locked.
+If you set this capability, you must remove it again before applying a service pack, installing an update, or uninstalling, as it results in the product binaries being locked.
 
 To remove the capability, run the following command:
 

--- a/content/en/docs/apim_administration/apigtw_admin/manage_operations.md
+++ b/content/en/docs/apim_administration/apigtw_admin/manage_operations.md
@@ -224,11 +224,11 @@ For example, the following directories include API Gateway configuration, and wi
 <install-dir>/apigateway/system/conf/nodemanager.xml
 ```
 
-### Back up before applying a service pack
+### Back up before applying a service pack or installing an update
 
-A service pack requires a full backup of the gateway installation, to enable you to restore the previous installation.
+Updates or service packs require a full backup of the API Gateway installation, to enable you to restore the previous installation.
 
-For example, the following directories should always be backed up before applying a service pack:
+For example, the following directories should always be backed up before applying a service pack or installing an update:
 
 ```
 <install-dir>/apigateway/conf

--- a/content/en/docs/apim_administration/apigtw_admin/managetopology.md
+++ b/content/en/docs/apim_administration/apigtw_admin/managetopology.md
@@ -59,9 +59,9 @@ For example:
 
 ## Check the installed version number of API Gateway instances {#check-installed-version}
 
-The installed product version number and any installed service pack are displayed in the API Gateway Manager topology and grid views.
+The installed product version number and any installed service packs or updates are displayed in the API Gateway Manager topology and grid views.
 
-When no service pack is installed on a system, API Gateway Manager shows the product version (for example, `7.7`). If a service pack is installed API Gateway Manager shows the product version and the service pack number (for example, `7.7 SP1`).
+When no service pack or update is installed on a system, API Gateway Manager shows the product version (for example, `7.7`). If a service pack or update is installed API Gateway Manager shows the product version and the service pack or update number (for example, `7.7 SP1`).
 
 The version information is the same for all processes running on a host as they all use the same physical installation. Version information is shown at the host and gateway level. Version information is not shown at the group level as groups can span multiple hosts.
 

--- a/content/en/docs/apim_administration/apigtw_admin/trblshoot_get_help.md
+++ b/content/en/docs/apim_administration/apigtw_admin/trblshoot_get_help.md
@@ -22,11 +22,11 @@ To view the installed version number in Policy Studio, select **Help > About Pol
 
 ### API Gateway Manager
 
-You can view the installed version number, including any installed service pack, for API Gateway instances in API Gateway Manager. For more information, see [Check the installed version number of API Gateway instances](/docs/apim_administration/apigtw_admin/managetopology#check-installed-version).
+You can view the installed version number, including any installed service packs or updates, for API Gateway instances in API Gateway Manager. For more information, see [Check the installed version number of API Gateway instances](/docs/apim_administration/apigtw_admin/managetopology#check-installed-version).
 
 ### Process listing
 
-You can list the API Gateway processes to view the installed version number, including any installed service pack. For example:
+You can list the API Gateway processes to view the installed version number, including any installed service pack or update. For example:
 
 ```
 $ ps -eaf | grep vshell
@@ -36,7 +36,7 @@ user1 19595 13643  0 Nov14 pts/23   00:06:05 NodeManager on Host1 (Node Manager 
 
 ### Trace file
 
-You can find the installed version number, including any installed service pack, in the header of the trace files for the Node Manager, API Gateway instance, or API Gateway Analytics server. For more information on where to find the trace files, see [Configure API Gateway diagnostic trace](/docs/apim_administration/apigtw_admin/tracing).
+You can find the installed version number, including any installed service pack or update, in the header of the trace files for the Node Manager, API Gateway instance, or API Gateway Analytics server. For more information on where to find the trace files, see [Configure API Gateway diagnostic trace](/docs/apim_administration/apigtw_admin/tracing).
 
 For example, the following trace file (for a Node Manager) shows the installed version and service pack:
 
@@ -49,7 +49,7 @@ For example, the following trace file (for a Node Manager) shows the installed v
 
 ## Find your installed version and list patches using managedomain {#find-install-version}
 
-You can use the `managedomain` command with the `-v` or `--version` options to find the installed version number, including any installed service pack or patches, and build information.
+You can use the `managedomain` command with the `-v` or `--version` options to find the installed version number, including any installed service pack, update, or patches, and build information.
 
 The following example shows the output for a system with API Gateway 7.7 installed, with service pack `SP1` installed, and no patches installed:
 
@@ -61,7 +61,7 @@ Commit Id:  05a6440fc3128d8d2f3dfe105904d04fffae67ea
 Patch:      None
 ```
 
-The `Build Date` and `Commit Id` fields in the output relate to the main product version (or the service pack, if one is installed). These fields are updated when a service pack is installed, but they are not updated when a patch is installed.
+The `Build Date` and `Commit Id` fields in the output relate to the main product version (or the service pack or update, if one is installed). These fields are updated when a service pack or update is installed, but they are not updated when a patch is installed.
 
 When patches are installed, `managedomain --version` displays the names of the patches installed. Patches are named after the internal ticket number and related commit ID (for example, `RDAPI-4563_3y7shb87635bhsaf7864nckzj7r9mp8744n8asa`). It also validates the installed patches and displays messages about any problems with the patch installation.
 
@@ -115,7 +115,7 @@ For more information on the patch validation messages and how to resolve them, s
 
 The `managedomain --version` command checks the version on the local machine only. You do not need to have an Admin Node Manager or API Gateway running to run this command.
 
-This command lists version information relating to what is installed on disk. You must stop your Node Manager and API Gateways before installing service packs and patches, you must restart them after installation, or the output of this command might not reflect what is loaded for the runtime of the Node Manager and API Gateways.
+This command lists version information relating to what is installed on disk. You must stop your Node Manager and API Gateways before installing service packs, updates, and patches, you must restart them after installation, or the output of this command might not reflect what is loaded for the runtime of the Node Manager and API Gateways.
 
 This command can also be run in command interpreter mode.
 
@@ -124,7 +124,7 @@ This command can also be run in command interpreter mode.
 It is important to include as much information as possible when contacting the Axway Support team. This helps to diagnose and solve the problem in a more efficient manner. The following information should be included with any Support query:
 
 * Name and version of the product (for example,  API Gateway 7.7).
-* Details of any service pack or patches that were applied to the product, if any.
+* Details of any service pack, update, or patches that were applied to the product, if any.
 * Operating system on which the product is running.
 * A clear (step-by-step) description of the problem or query.
 * If you have encountered an error, the error message should be included in the email. It is also useful to include any relevant trace files from the `/trace` directory of your product installation, preferably with the trace level set to `DEBUG`.

--- a/content/en/docs/apim_installation/apigtw_install/install_service_packs.md
+++ b/content/en/docs/apim_installation/apigtw_install/install_service_packs.md
@@ -6,9 +6,9 @@
 "description": "Apply service packs or patches to API Gateway components."
 }
 
-## Install a service pack or patch
+## Apply a service pack or patch
 
-To install a service pack or patch on an existing installation of API Gateway, follow these general guidelines:
+To apply a service pack or patch to an existing installation of API Gateway, follow these general guidelines:
 
 1. Stop any Node Managers and API Gateway servers.
 2. Back up your existing installation. For more information on backing up, see [API Gateway backup and disaster recovery](/docs/apim_administration/apigtw_admin/manage_operations/#api-gateway-backup-and-disaster-recovery).

--- a/content/en/docs/apim_installation/apigw_containers/container_patch_sp.md
+++ b/content/en/docs/apim_installation/apigw_containers/container_patch_sp.md
@@ -8,9 +8,9 @@ description: Apply a patch or a service pack (SP) to an API Gateway or API Manag
 
 In a container deployment, a patch or service pack is rolled out using an orchestration tool (for example, Kubernetes or OpenShift) after new Docker images containing the patch or service pack are pushed to the Docker registry. This enables you to perform a rolling zero downtime update of services.
 
-## Install a patch
+## Apply a patch
 
-To install a patch, follow these steps:
+To apply a patch, follow these steps:
 
 1. Download the patch from Axway Support at [https://support.axway.com](https://support.axway.com/).
 2. Create a merge directory to contain the patch files and any custom configuration (for example, `/tmp/apigateway`). The merge directory must be called `apigateway` and must have the same directory structure as the `apigateway` directory of an API Gateway installation.
@@ -24,9 +24,9 @@ To install a patch, follow these steps:
     ./build_gw_image.py --license=/tmp/api_gw.lic --domain-cert=certs/mydomain/mydomain-cert.pem --domain-key=certs/mydomain/mydomain-key.pem --domain-key-pass-file=/tmp/pass.txt --merge-dir=/tmp/apigateway
     ```
 
-## Install a service pack
+## Apply a service pack
 
-To install a service pack, follow these steps:
+To apply a service pack, follow these steps:
 
 1. Download the latest API Gateway 7.7 Linux installer (which includes the service pack) from Axway Support at [https://support.axway.com](https://support.axway.com/).
 2. Create a new base image using the `--installer` option to build the image from the downloaded API Gateway installer.

--- a/content/en/docs/apim_installation/apigw_upgrade/upgrade_overview.md
+++ b/content/en/docs/apim_installation/apigw_upgrade/upgrade_overview.md
@@ -16,7 +16,7 @@ Before you proceed with an upgrade, note the following:
 
 The upgrade and migration process involves exporting data from your old installation, upgrading the data, and applying the upgraded data to your new installation. Each step must complete successfully before you can proceed to the next step.
 
-{{< alert title="Note" color="primary" >}}After you have installed API Gateway 7.7, ensure you have installed the latest available service pack before starting the upgrade. {{< /alert >}}
+{{< alert title="Note" color="primary" >}}After you have installed API Gateway 7.7, ensure you have applied the latest available service pack before starting the upgrade. {{< /alert >}}
 
 ![Overview of upgrade process](/Images/UpgradeGuide/APIgw_ETLUpgrade.png)
 
@@ -27,7 +27,7 @@ API Gateway provides the `sysupgrade` command to upgrade your API Gateway system
 An upgrade always requires the following steps:
 
 1. Install API Gateway 7.7 in a new directory.
-2. Install the latest available service pack for API Gateway 7.7.
+2. Apply the latest available service pack for API Gateway 7.7.
 3. Export the data from the old installation.
 4. Validate and upgrade the data. Resolve any issues identified by the upgrade process before you proceed to the next step.
 5. Apply the upgraded data to the 7.7 installation.

--- a/content/en/docs/apim_installation/apigw_upgrade/upgrade_steps_extcass.md
+++ b/content/en/docs/apim_installation/apigw_upgrade/upgrade_steps_extcass.md
@@ -82,9 +82,9 @@ Check your old installation and identify if you are using any of the following:
 
 Perform the following in your new API Gateway 7.7 installation.
 
-#### Install the latest service pack
+#### Apply the latest service pack
 
-Install the latest available service pack for your new installation. Service packs are available from [Axway Support](https://support.axway.com/).
+Apply the latest available service pack for your new installation. Service packs are available from [Axway Support](https://support.axway.com/).
 
 #### Do not start any Node Managers or API Gateways in the new installation
 

--- a/content/en/docs/apim_installation/apiportal_docker/Upgrade_docker.md
+++ b/content/en/docs/apim_installation/apiportal_docker/Upgrade_docker.md
@@ -8,8 +8,7 @@
 
 This topic describes how to upgrade an API Portal Docker deployment. The upgrade preserves any API Portal customizations (for example, new menus, new templates, localizations, and so on).
 
-* Upgrade to API Portal 7.7 is supported from API Portal 7.6.2 only. To upgrade from earlier versions, you must first upgrade to 7.6.2.
-* API Portal 7.7 is compatible with API Gateway and API Manager 7.7 only.
+Upgrade to API Portal 7.7 is supported from API Portal 7.6.2 only. To upgrade from earlier versions, you must first upgrade to 7.6.2.
 
 {{< alert title="Caution" color="warning" >}}
 

--- a/content/en/docs/apim_installation/apiportal_install/install_service_pack.md
+++ b/content/en/docs/apim_installation/apiportal_install/install_service_pack.md
@@ -8,11 +8,11 @@
 
 Service packs and patches provide important security updates, fixes for known issues, and improved performance for API Portal and its components.
 
-## Install a service pack or patch on a software installation
+## Apply a service pack or patch on a software installation
 
-You can download the service pack and the associated Readme file from Axway Support at [https://support.axway.com](https://support.axway.com/). Review the Readme for any specific installation instructions before you install the service pack.
+You can download the service pack and the associated Readme file from Axway Support at [https://support.axway.com](https://support.axway.com/). Review the Readme for any specific instructions before you apply the service pack.
 
-## Install a service pack or patch on a container deployment
+## Apply a service pack or patch on a container deployment
 
 To apply a service pack or patch to a container deployment:
 

--- a/content/en/docs/apim_installation/apiportal_install/upgrade_automatic.md
+++ b/content/en/docs/apim_installation/apiportal_install/upgrade_automatic.md
@@ -19,10 +19,7 @@ Before you upgrade, complete the following prerequisites. These prerequisites ap
 
 If you have an existing API Portal installation, you can upgrade that installation to a newer version without having to repeat the initial setup.
 
-* Upgrade to API Portal 7.7.20200130 is supported from API Portal 7.7.x only. To upgrade from earlier versions, you must first upgrade to 7.7.
-* Upgrade to API Portal 7.7 is supported from API Portal 7.6.2 only. To upgrade from earlier versions, you must first upgrade to 7.6.2.
-* API Portal 7.7 GA and API Portal 7.7 SP1 to SP4 is compatible with API Gateway and API Manager 7.7 GA and API Gateway and API Manager 7.7 SP1 to SP2 only.
-* API Portal 7.7.20200130 is compatible with API Gateway and API Manager 7.7.20200130 only.
+Upgrade to API Portal 7.7 is supported from API Portal 7.6.2 only. To upgrade from earlier versions, you must first upgrade to 7.6.2.
 
 To upgrade your API Portal software installation, follow these steps:
 

--- a/content/en/docs/apim_relnotes/20200130_apimgr_relnotes/_index.md
+++ b/content/en/docs/apim_relnotes/20200130_apimgr_relnotes/_index.md
@@ -172,11 +172,11 @@ The following are known issues for this release.
 
 ## Update a classic (non-container) deployment
 
-These instructions apply to API Gateway and API Manager classic deployments only. For container deployments, see [Apply a patch or service pack](/docs/apim_installation/apigw_containers/container_patch_sp/).
+These instructions apply to API Gateway and API Manager classic deployments only. For container deployments, see [Update a container deployment](#update-a-container-deployment).
 
 ### Prerequisites
 
-This service pack has the following prerequisites in addition to the [System requirements](/docs/apim_installation/apigtw_install/system_requirements/).
+This update has the following prerequisites in addition to the [System requirements](/docs/apim_installation/apigtw_install/system_requirements/).
 
 1. Shut down any Node Manager or API Gateway instances on your existing installation.
 2. Back up your existing installation. For details on backing up, see [API Gateway backup and disaster recovery](/docs/apim_administration/apigtw_admin/manage_operations/#api-gateway-backup-and-disaster-recovery).
@@ -215,12 +215,12 @@ This service pack has the following prerequisites in addition to the [System req
 
 ### FIPS mode only
 
-If FIPS mode is enabled, you must also perform the following steps to install the service pack:
+If FIPS mode is enabled, you must also perform the following steps to install the update:
 
 1. Run `togglefips --disable` to turn FIPS mode off.
 2. Start the Node Manager to move the JARs.
 3. Stop the Node Manager.
-4. Install the API Gateway service pack.
+4. Install the API Gateway update.
 5. Start the Node Manager.
 6. Stop the Node Manager.
 7. Run `togglefips --enable` to turn FIPS on again.
@@ -228,18 +228,18 @@ If FIPS mode is enabled, you must also perform the following steps to install th
 
 ### Installation
 
-This section describes how to install the service pack on existing 7.7 installations of API Gateway or API Manager.
+This section describes how to install the update on existing 7.7 installations of API Gateway or API Manager.
 
-* If you have installed an existing version of API Manager, installing the API Gateway server service pack automatically also installs the updates and fixes for API Manager.
-* If you have installed a licensed version of API Gateway or API Manager 7.7, you do not require a new license to install service packs.
+* If you have installed an existing version of API Manager, installing the API Gateway server update automatically also installs the updates and fixes for API Manager.
+* If you have installed a licensed version of API Gateway or API Manager 7.7, you do not require a new license to install updates.
 
-#### Install the API Gateway server service pack
+#### Install the API Gateway server update
 
-To install the service pack on your existing API Gateway 7.7 server installation, perform the following steps:
+To install the update on your existing API Gateway 7.7 server installation, perform the following steps:
 
 1. Ensure that your existing API Gateway instance and Node Manager have been stopped.
-2. Remove any previous patches from your `INSTALL_DIR/ext/lib` and `INSTALL_DIR/META-INF` directories (or the `ext/lib` directory in an API Gateway instance). These patches have already been included in this service pack. You do not need to copy patches from a previous version.
-3. Verify the owners of API Gateway binaries before extracting the service pack.
+2. Remove any previous patches from your `INSTALL_DIR/ext/lib` and `INSTALL_DIR/META-INF` directories (or the `ext/lib` directory in an API Gateway instance). These patches have already been included in this update. You do not need to copy patches from a previous version.
+3. Verify the owners of API Gateway binaries before extracting the update.
 
     ```
     ls -l INSTALL_DIR/apigateway/posix/bin
@@ -263,9 +263,9 @@ To install the service pack on your existing API Gateway 7.7 server installation
     apigw_sp_post_install.sh
     ```
 
-#### Install the Policy Studio service pack
+#### Install the Policy Studio update
 
-To install the service pack on your existing Policy Studio installation, perform the following steps:
+To install the update on your existing Policy Studio installation, perform the following steps:
 
 1. Shut down Policy Studio.
 2. Back up your existing `INSTALL_DIR/policystudio` directory.
@@ -283,9 +283,9 @@ To install the service pack on your existing Policy Studio installation, perform
 
 5. Start Policy Studio with `policystudio -clean`
 
-#### Install the Configuration Studio service pack
+#### Install the Configuration Studio update
 
-To install the service pack on your existing Configuration Studio installation, perform the following steps:
+To install the update on your existing Configuration Studio installation, perform the following steps:
 
 1. Shut down Configuration Studio.
 2. Back up your existing `INSTALL_DIR/configurationstudio` directory.
@@ -303,12 +303,12 @@ To install the service pack on your existing Configuration Studio installation, 
 
 5. Start Configuration Studio with `configurationstudio  -clean`
 
-#### Install the API Gateway Analytics service pack
+#### Install the API Gateway Analytics update
 
-To install the service pack on your existing API Gateway Analytics 7.7 installation, perform the following steps:
+To install the update on your existing API Gateway Analytics 7.7 installation, perform the following steps:
 
 1. Ensure that your existing API Gateway Analytics instance and Node Manager have been stopped.
-2. Verify the owners of API Gateway binaries before extracting the service pack.
+2. Verify the owners of API Gateway binaries before extracting the update.
 
     ```
     ls -l INSTALL_DIR/analytics/posix/bin
@@ -332,11 +332,11 @@ To install the service pack on your existing API Gateway Analytics 7.7 installat
     apigw_analytics_sp_post_install.sh
     ```
 
-You must also install a service pack for your existing API Gateway 7.7 server.
+You must also install an update for your existing API Gateway 7.7 server.
 
 ### After installation
 
-The following steps apply after installing the service pack.
+The following steps apply after installing the update.
 
 #### API Gateway
 
@@ -365,7 +365,7 @@ When API Manager is installed, you must run the `update-apimanager` script after
 {{< alert title="Caution" color="warning" >}}
 Before executing the `update-apimanager` script:
 
-* Apply the service pack to all API Gateways.
+* Apply the update to all API Gateways.
 * Ensure that all Node Managers and API Gateway instances are running.
 
 {{< /alert >}}
@@ -392,9 +392,9 @@ If the API Gateway group is protected by a passphrase, you must append the comma
 
 ## Update a container deployment
 
-If a `fed` file is provided as part of building the API Manager container, you must follow these steps to update the `fed` with the Service Pack API Manager configuration:
+If a `fed` file is provided as part of building the API Manager container, you must follow these steps to update the `fed` with the configuration changes:
 
-1. Install the Service Pack on a installation of the API Gateway.
+1. Install the update on a installation of the API Gateway.
 2. Run the following command:
 
     ```
@@ -403,7 +403,7 @@ If a `fed` file is provided as part of building the API Manager container, you m
 
 You do not need to run any API Manager instances.
 
-The `fed` now contains the Service Pack updates for the API Manager configuration and can be used to build containers.
+The `fed` now contains the updates for the API Manager configuration and can be used to build containers.
 
 ## Documentation
 

--- a/content/en/docs/apim_relnotes/20200130_apimgr_relnotes/fixed_issues.md
+++ b/content/en/docs/apim_relnotes/20200130_apimgr_relnotes/fixed_issues.md
@@ -6,7 +6,7 @@
 "description": "Listing of fixed issues in this release of API Gateway and API Manager."
 }
 
-This version of API Gateway and API Manager includes the fixes from all 7.5.5, 7.6.2, and 7.7 service packs or updates released prior to this version. For details of all the service pack fixes included, see corresponding _SP Readme_ attached to each service pack on [Axway Support](https://support.axway.com).
+This version of API Gateway and API Manager includes the fixes from all 7.5.3, 7.6.2, and 7.7 service packs or updates released prior to this version. For details of all the service pack fixes included, see corresponding _SP Readme_ attached to each service pack on [Axway Support](https://support.axway.com).
 
 ## Fixed security vulnerabilities
 

--- a/content/en/docs/apim_relnotes/20200130_apip_relnotes/_index.md
+++ b/content/en/docs/apim_relnotes/20200130_apip_relnotes/_index.md
@@ -69,7 +69,7 @@ For more information, see [Additional features for API Catalog view](/docs/apim_
 This release has the following limitations:
 
 * API Portal 7.7.20200130 is compatible with API Gateway and API Manager 7.7.20200130 only.
-* Upgrade to API Portal 7.7.20200130 is supported from API Portal 7.7 only. To upgrade from earlier versions, you must first upgrade to 7.7.
+* Upgrade to API Portal 7.7.20200130 is supported from API Portal 7.7 only. To upgrade from earlier versions, you must first upgrade to 7.7.
 * The ready-made API Portal Docker image is strictly for development environments only, and is not recommended for use in production environments. You must use the Dockerfile to build and run API Portal containers in production environments.
 * This release is not available as a virtual appliance, or as a managed service on Axway Cloud.
 

--- a/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
+++ b/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
@@ -44,7 +44,7 @@ The default idle session timeout for the API Gateway Manager web UI is 12 hours.
 
 ## Correct upgrade procedure
 
-In the event of a possible vulnerability discovered in the product, you must be able to apply the patch or new Service Pack as soon as possible. Make sure you have the correct procedure to complete the upgrade. Always use the latest version of the product, if possible, as it contains fixes to known vulnerabilities.
+In the event of a possible vulnerability discovered in the product, you must be able to apply the patch or new service pack as soon as possible. Make sure you have the correct procedure to complete the upgrade. Always use the latest version of the product, if possible, as it contains fixes to known vulnerabilities.
 
 For more information on upgrade procedures, see the following sections:
 


### PR DESCRIPTION
- Change or add "update" terminology so it's clear that 7.7.20200130 is an update and not a service pack
- Change all mentions of service pack use "apply" instead of "install" for consistency.
- Remove any specific mentions of this "update" version from generic docs. The update version should only be mentioned in RN. Similarly specific SP version should only be mentioned in the SP readme.

fixes #336 