### PR TITLE
Mention release notes in container_patch_sp.md

### DIFF
--- a/content/en/docs/apim_installation/apigw_containers/container_patch_sp.md
+++ b/content/en/docs/apim_installation/apigw_containers/container_patch_sp.md
@@ -13,10 +13,11 @@ In a container deployment, a patch or service pack is rolled out using an orches
 To apply a patch, follow these steps:
 
 1. Download the patch from Axway Support at [https://support.axway.com](https://support.axway.com/).
-2. Create a merge directory to contain the patch files and any custom configuration (for example, `/tmp/apigateway`). The merge directory must be called `apigateway` and must have the same directory structure as the `apigateway` directory of an API Gateway installation.
-3. Unzip and extract the patch into the merge directory.
-4. Add any custom configuration to the merge directory. For example, to add a custom `envSettings.props` file to your image, copy `envSettings.props` to `/tmp/apigateway/conf/`.
-5. Create new Admin Node Manager and API Gateway images using the `--merge-dir` option to specify the merge directory containing the patch files and custom configuration.
+2. Check the patch release notes for any special instructions to follow.
+3. Create a merge directory to contain the patch files and any custom configuration (for example, `/tmp/apigateway`). The merge directory must be called `apigateway` and must have the same directory structure as the `apigateway` directory of an API Gateway installation.
+4. Unzip and extract the patch into the merge directory.
+5. Add any custom configuration to the merge directory. For example, to add a custom `envSettings.props` file to your image, copy `envSettings.props` to `/tmp/apigateway/conf/`.
+6. Create new Admin Node Manager and API Gateway images using the `--merge-dir` option to specify the merge directory containing the patch files and custom configuration.
 
     ```
     cd emt_containers-<version>
@@ -29,16 +30,17 @@ To apply a patch, follow these steps:
 To apply a service pack, follow these steps:
 
 1. Download the latest API Gateway 7.7 Linux installer (which includes the service pack) from Axway Support at [https://support.axway.com](https://support.axway.com/).
-2. Create a new base image using the `--installer` option to build the image from the downloaded API Gateway installer.
+2. Check the service pack release notes for any special instructions to follow.
+3. Create a new base image using the `--installer` option to build the image from the downloaded API Gateway installer.
 
     ```
     cd emt_containers-<version>
     ./build_base_image.py --installer=apigw-new-installer.run --os=centos7
     ```
 
-3. Create a merge directory to contain any custom configuration (for example, `/tmp/apigateway`). The merge directory must be called `apigateway` and must have the same directory structure as the `apigateway` directory of an API Gateway installation.
-4. Add any custom configuration to the merge directory. For example, to add a custom `envSettings.props` file to your image, copy `envSettings.props` to `/tmp/apigateway/conf/`.
-5. Create new Admin Node Manager and API Gateway images using the `--merge-dir` option to specify the merge directory containing the custom configuration.
+4. Create a merge directory to contain any custom configuration (for example, `/tmp/apigateway`). The merge directory must be called `apigateway` and must have the same directory structure as the `apigateway` directory of an API Gateway installation.
+5. Add any custom configuration to the merge directory. For example, to add a custom `envSettings.props` file to your image, copy `envSettings.props` to `/tmp/apigateway/conf/`.
+6. Create new Admin Node Manager and API Gateway images using the `--merge-dir` option to specify the merge directory containing the custom configuration.
 
     ```
     cd emt_containers-<version>


### PR DESCRIPTION
SP/patch application instructions should mention that the release notes always need to be consulted because they may contain special instructions specific to that release.