### PR TITLE
docs(menu): add link to API docs page in header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,6 +60,13 @@ languageName ="English"
 # Weight used for sorting.
 weight = 1
 
+# Navigation Bar Menu
+
+[[menu.main]]
+name = "API Docs"
+weight = 25
+url = "https://docs.axway.com/category/api"
+
 # Everything below this are Site Params
 
 [params]


### PR DESCRIPTION
Hi 👋 

The Appcelerator team is looking at potential doc site changes, so I'm testing out how we might be able to eventually integrate here. This change may be useful, I'm attempting to add a header menu link to the API docs section of docs.axway.com. The site as it exists appears to be more about "guides", and if users are interested in the raw API specs, having a top-level menu link may be useful (or potentially having it have links for each product to the exact URL for that product's API doc pages)