### PR TITLE
APIG install section “system_requirements” missing for Linux

### DIFF
--- a/content/en/docs/apim_installation/apigtw_install/system_requirements.md
+++ b/content/en/docs/apim_installation/apigtw_install/system_requirements.md
@@ -1,9 +1,9 @@
 {
 "title": "System requirements",
-"linkTitle": "System requirements",
-"weight":"4",
-"date": "2019-10-02",
-"description": "Supported platforms and other system requirements for API Gateway, and specific requirements for API Gateway components."
+  "linkTitle": "System requirements",
+  "weight": "4",
+  "date": "2019-10-02",
+  "description": "Supported platforms and other system requirements for API Gateway, and specific requirements for API Gateway components."
 }
 
 {{< alert title="Note" color="primary" >}}Windows is supported only for a limited set of developer tools, see [Install developer tools on Windows](/docs/apim_installation/apigtw_install/install_dev_tools/). API Gateway and API Manager do not support Windows.{{< /alert >}}
@@ -46,6 +46,9 @@ Axway makes every effort to add support for new kernels and distributions in a t
 ### Disk space and RAM requirements
 
 The disk space and RAM requirements for Linux platforms are:
+
+* Disk space: minimum 4 GB, 50 GB recommended
+* Physical memory (RAM): minimum 8 GB
 
 The disk space and RAM requirements for the developer tools on Windows platforms are:
 

--- a/content/en/docs/apim_installation/apigtw_install/system_requirements.md
+++ b/content/en/docs/apim_installation/apigtw_install/system_requirements.md
@@ -47,8 +47,8 @@ Axway makes every effort to add support for new kernels and distributions in a t
 
 The disk space and RAM requirements for Linux platforms are:
 
-* Disk space: minimum 4 GB, 50 GB recommended
-* Physical memory (RAM): minimum 8 GB
+* Disk space: minimum 4 GB, 50 GB recommended
+* Physical memory (RAM): minimum 8 GB
 
 The disk space and RAM requirements for the developer tools on Windows platforms are:
 


### PR DESCRIPTION
Copied the requirements from 7.6.2 - assuming they have not changed  https://docs.axway.com/bundle/APIGateway_762_InstallationGuide_allOS_en_HTML5/page/Content/InstallGuideTopics/system_requirements.htm