### PR TITLE
Add size-label to the tickets

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,0 +1,17 @@
+name: size-label
+
+# GitHub action to assign labels based on pull request change sizes.
+# https://github.com/marketplace/actions/assign-size-label
+
+on: pull_request
+jobs:
+  size-label:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: size-label
+        uses: "pascalgn/size-label-action@df7ad4303b35cbeb20937dbb12d5a050520e469e"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
@alexearnshaw I think that this [Assign size label](https://github.com/marketplace/actions/assign-size-label) action is what we're looking for.  What I liked about it is that it uses the same labels as the [Kubernetes](https://github.com/kubernetes/kubernetes/labels?q=size) project.

Following the '**Usage**' instructions, I simply created this `.github/workflows/size-label.yml` file with the recommended code. 

In '**Configuration**' I don't know what this env variable mean. I'm not sure if this is something that we must have in the project or if it's something optional, and when we merge this new file to our project, it will automatically label the new PRs.