### PR TITLE
Add conflict-label to the tickets

### DIFF
--- a/.github/workflows/conflict-label.yml
+++ b/.github/workflows/conflict-label.yml
@@ -1,6 +1,6 @@
 name: 'Check for merge conflicts'
 on:
-  pull:
+  pull_request:
     branches:
       - master
 jobs:

--- a/.github/workflows/conflict-label.yml
+++ b/.github/workflows/conflict-label.yml
@@ -1,0 +1,13 @@
+name: 'Check for merge conflicts'
+on:
+  pull:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'has conflicts'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conflict-label.yml
+++ b/.github/workflows/conflict-label.yml
@@ -1,6 +1,6 @@
 name: 'Check for merge conflicts'
 on:
-  pull_request:
+  push:
     branches:
       - master
 jobs:


### PR DESCRIPTION
@alexearnshaw I've found this [Auto-label merge conflicts](https://github.com/marketplace/actions/auto-label-merge-conflicts) GitHub action, which is also helpful. Sometimes is not easy to see that there's a conflict, but with the issue being automatically labeled, it will be easier to see.

The only think I've changed from the original example file is that they add the label **on push**, and I've set ours to **on pull**. So I'm not sure if this is going to work :)



