### PR TITLE
Location of the server key and certificate fixed

### DIFF
--- a/content/en/docs/apim_installation/apiportal_docker/docker_troubleshoot.md
+++ b/content/en/docs/apim_installation/apiportal_docker/docker_troubleshoot.md
@@ -41,9 +41,9 @@ After the API Portal container is started, the Apache daemon is not started and
 
 2. Verify whether the following files exist on the API Portal Docker container. Those files are the certificates used by API Portal when you connect over HTTPS. Apache will not start if these files are missing.
 
-    `/etc/httpd/server.key`
+    `/etc/httpd/conf/server.key`
 
-    `/etc/httpd/server.crt`
+    `/etc/httpd/conf/server.crt`
 
 3. If the files do not exist, either generate them using `/tmp/genssl.sh` script, or provide your own certificates.
 


### PR DESCRIPTION
The location of the server key & certificate was wrong. From:
```
/etc/httpd/server.key
/etc/httpd/server.crt
```
to:
```
/etc/httpd/conf/server.key
/etc/httpd/conf/server.crt
```

I double checked it in the mentioned script: `/tmp/genssl.sh`:

```
KEY=$APACHE_ROOT/conf/server.key
CRT=$APACHE_ROOT/conf/server.crt
LOCK=$APACHE_ROOT/conf/server.key.lock
```

## Checklist for contributors

Before submitting this PR, please make sure:

* [X] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [X] You have signed the [Axway CLA](https://cla.axway.com/)
* [X] You have verified the technical accuracy of your change
* [X] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [ ] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links
* [ ] Is discoverable and navigable

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a size label (unless this work is tracked in the ReadMeFirst JIRA project)
* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added it to the correct Sprint milestone
* [ ] You have appended a `fixes` line to this description if this PR fixes a specific GitHub issue
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new AMPC topics)
