### PR TITLE
Add Unified Catalog to CMS

### DIFF
--- a/static/admin/config.js
+++ b/static/admin/config.js
@@ -292,7 +292,7 @@ const collections = [{
   description: 'All pages relating to AMPLIFY Central.',
   format: 'frontmatter',
 }, {
-  ...docsDefaults('catalog', 'catalog'),
+  ...docsDefaults('central/catalog', 'central/catalog'),
   name: 'catalog',
   label: 'AMPLIFY Unified Catalog documentation',
   label_singular: 'page in AMPLIFY Unified Catalog',


### PR DESCRIPTION
Complements #513 

@alexearnshaw PR 513 didn't work, I think because I should've added 'central' before 'Catalog'


## Describe the changes

Enter a brief description of your changes here to communicate to the maintainers what you changed and why.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [ ] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links
* [ ] Is discoverable and navigable

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a size label (unless this work is tracked in the ReadMeFirst JIRA project)
* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added it to the correct Sprint milestone
* [ ] You have appended a `fixes` line to this description if this PR fixes a specific GitHub issue
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new AMPC topics)
