### PR TITLE
Specify version of markdownlint-cli for CI to avoid unexpected breaks.

### DIFF
--- a/.github/workflows/ciworkflow.yml
+++ b/.github/workflows/ciworkflow.yml
@@ -29,5 +29,5 @@ jobs:
     # Runs markdownlint
     - name: Run markdown linter
       run: |
-        npm i -g markdownlint-cli
+        npm i -g markdownlint-cli@0.22.0
         markdownlint "content/en/**/*.md"      


### PR DESCRIPTION
Context: https://github.com/Axway/axway-open-docs/pull/696#issuecomment-624269827