### PR TITLE
[SPHERE-1046] Fix broken links in SphereAPI(Support API) docs

### DIFF
--- a/content/en/docs/shared_services/supportapi/formats/add_note_res.md
+++ b/content/en/docs/shared_services/supportapi/formats/add_note_res.md
@@ -13,7 +13,7 @@ description: Response format for the Add Note method.
 | caseId        | string                        |       no | The ID of the case that this note is related to. The ID is also referred to as case number. |
 | subject       | string                        |       no | Title or subject of this note. |
 | description   | string                        |       no | Detailed information included in this note. |
-| addedDate     | string                        |       no | Date and time of note creation. [Format](../miscellaneous#common-date-and-time-format-for-responses).|
+| addedDate     | string                        |       no | Date and time of note creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses).|
 | attachments   | [ [Attachment](#attachment) ] |      yes | Summary information about the files attached to this note. |
 | createdBy     | string                        |      yes | The creator of this note. |
 
@@ -23,4 +23,4 @@ description: Response format for the Add Note method.
 |---------------|-----------|----------|-------------|
 | id            | string    |       no | An identifier of this attachment. Attachment download requires this ID.|
 | name          | string    |       no | The name under which this attachment was added. |
-| createdDate   | string    |       no | Date and time of attachment creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
+| createdDate   | string    |       no | Date and time of attachment creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |

--- a/content/en/docs/shared_services/supportapi/formats/close_case_res.md
+++ b/content/en/docs/shared_services/supportapi/formats/close_case_res.md
@@ -13,20 +13,20 @@ description: Response format for the Close Case method.
 | caseNumber    | string                        |       no | Business identifier assigned to this case. |
 | subject       | string                        |       no | Brief description of this case. |
 | status        | string                        |       no | The current status of this case. |
-| closedDate    | string                        |      yes | Date and time of case closure. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| createdDate   | string                        |       no | Date and time of case creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| modifiedDate  | string                        |       no | Date and time of the latest update. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| severity      | [Severity](../severity)       |       no | The severity level calculated for this case. |
+| closedDate    | string                        |      yes | Date and time of case closure. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| createdDate   | string                        |       no | Date and time of case creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| modifiedDate  | string                        |       no | Date and time of the latest update. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| severity      | [Severity](/docs/shared_services/supportapi/formats/severity)       |       no | The severity level calculated for this case. |
 | account       | [Account](#account)           |       no | Details of the Axway customer account that case is registered with. |
 | contact       | [Contact](#contact)           |       no | Current contact for this case. |
 | owner         | [Contact](#contact)           |      yes | The current owner of this case. |
 | description   | string                        |       no | Detailed description of this case. |
-| environment   | [Environment](../environment) |       no | Environment for which this case is created. |
+| environment   | [Environment](/docs/shared_services/supportapi/formats/environment) |       no | Environment for which this case is created. |
 | notes         | [ [CaseNote](#casenote) ]     |      yes | List of all case notes attached to this case. |
 | product       | [Product](#product)           |       no | Product for which this case was created. |
 | attachments   | [ [Attachment](#attachment) ] |      yes | Summary information about the files attached to this case. |
 | ccEmails      | [ string ]                    |      yes | E-mail addresses copied in communications regarding this case. |
-| type          | [CaseType](../case_type)      |       no | The type of this case. |
+| type          | [CaseType](/docs/shared_services/supportapi/formats/case_type)      |       no | The type of this case. |
 
 ### Account
 
@@ -82,5 +82,5 @@ description: Response format for the Close Case method.
 |---------------|---------------------|----------|-------------|
 | id            | string              |       no | An identifier of this attachment. Attachment download requires this ID.|
 | name          | string              |       no | The name under which this attachment was added. |
-| createdDate   | string              |       no | Date and time of attachment creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
+| createdDate   | string              |       no | Date and time of attachment creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
 | createdBy     | [Contact](#contact) |      yes | Contact that added this attachment. |

--- a/content/en/docs/shared_services/supportapi/formats/create_case_req.md
+++ b/content/en/docs/shared_services/supportapi/formats/create_case_req.md
@@ -14,9 +14,9 @@ description: Request format for the Create Case method.
 | subject       | string                        |       no | Brief description of this case. |
 | description   | string                        |       no | Detailed description of this case. |
 | product       | [Product](#product)           |       no | Affected product. |
-| environment   | [Environment](../environment) |       no | Environment for which this case is created. |
+| environment   | [Environment](/docs/shared_services/supportapi/formats/environment) |       no | Environment for which this case is created. |
 | impact        | [Impact](#impact)             |       no | Impact level. |
-| urgency       | [Urgency](../urgency)         |       no | Urgency level. |
+| urgency       | [Urgency](/docs/shared_services/supportapi/formats/urgency)         |       no | Urgency level. |
 | type          | [CaseType](#casetype)         |      yes | The type of this case. Default: `Support Case`. |
 | ccEmails      | [ string ]                    |      yes | E-mail addresses to be copied in communications regarding this case. |
 
@@ -30,7 +30,7 @@ Impact levels supported in Create Case requests to the API, as an open-ended enu
     * 3 - Mediums
     * 4 - Low
 
-For details on the different enumeration elements, please refer to [Impact](../impact).
+For details on the different enumeration elements, please refer to [Impact](/docs/shared_services/supportapi/formats/impact).
 
 ### CaseType
 
@@ -41,12 +41,12 @@ Case types supported in Create Case requests to the API, as an open-ended enumer
     * Support Case
     * Enhancement Request
 
-See also the full classification [here](../case_type).
+See also the full classification [here](/docs/shared_services/supportapi/formats/case_type).
 
 ### Product
 
 {{% alert title="Note" %}}
-Product, product version and product operating system identifiers can be obtained with a call to the [Get Products](../../methods/get_products) method.
+Product, product version and product operating system identifiers can be obtained with a call to the [Get Products](/docs/shared_services/supportapi/methods/get_products) method.
 {{% /alert %}}
 
 | Property Name | Data Type                         | Optional | Description |

--- a/content/en/docs/shared_services/supportapi/formats/create_case_res.md
+++ b/content/en/docs/shared_services/supportapi/formats/create_case_res.md
@@ -12,23 +12,23 @@ description: Response format for the Create Case method.
 |---------------|-------------------------------|----------|-------------|
 | caseNumber    | string                        |       no | Business identifier assigned to this case. |
 | subject       | string                        |       no | Brief description of this case. |
-| severity      | [Severity](../severity)       |       no | The severity level calculated for this case. |
+| severity      | [Severity](/docs/shared_services/supportapi/formats/severity)       |       no | The severity level calculated for this case. |
 | status        | string                        |       no | The current status of this case. |
-| createdDate   | string                        |       no | Date and time of case creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| modifiedDate  | string                        |       no | Date and time of the latest update. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
+| createdDate   | string                        |       no | Date and time of case creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| modifiedDate  | string                        |       no | Date and time of the latest update. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
 | contact       | [Contact](#contact)           |       no | Current contact for this case. |
 | owner         | [Contact](#contact)           |      yes | The current owner of this case. |
 | product       | [Product](#product)           |       no | Product for which this case was created. |
-| environment   | [Environment](../environment) |       no | Environment for which this case is created. |
+| environment   | [Environment](/docs/shared_services/supportapi/formats/environment) |       no | Environment for which this case is created. |
 | notes         | [ [CaseNote](#casenote) ]     |      yes | List of case notes automatically attached to this case on case creation. |
 | impact        | [Impact](#impact)             |       no | Impact level. |
-| urgency       | [Urgency](../urgency)         |       no | Urgency level. |
-| type          | [CaseType](../case_type)      |       no | The type of this case. |
+| urgency       | [Urgency](/docs/shared_services/supportapi/formats/urgency)         |       no | Urgency level. |
+| type          | [CaseType](/docs/shared_services/supportapi/formats/case_type)      |       no | The type of this case. |
 | description   | string                        |       no | Detailed description of this case. |
 | ccEmails      | [ string ]                    |      yes | E-mail addresses copied in communications regarding this case. |
 | attachments   | [ [Attachment](#attachment) ] |      yes | Summary information about the files attached to this case. |
 | account       | [Account](#account)           |       no | Details of the Axway customer account that case is registered with. |
-| closedDate    | string                        |      yes | Date and time of case closure. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
+| closedDate    | string                        |      yes | Date and time of case closure. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
 
 ### Contact
 
@@ -67,7 +67,7 @@ description: Response format for the Create Case method.
 |---------------|-----------|----------|-------------|
 | id            | string    |       no | An identifier of this attachment. Attachment download requires this ID.|
 | name          | string    |       no | The name under which this attachment was added. |
-| createdDate   | string    |       no | Date and time of attachment creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
+| createdDate   | string    |       no | Date and time of attachment creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
 
 ### Account
 

--- a/content/en/docs/shared_services/supportapi/formats/error_response.md
+++ b/content/en/docs/shared_services/supportapi/formats/error_response.md
@@ -50,7 +50,7 @@ Each error class is accompanied by a specific HTTP status code. The table below 
 
 `SERVER_ERROR`
 
-* A non-atomic method, such as [Create Case](../../methods/create_case) or [Add Note](../../methods/add_note), completed only partially:
+* A non-atomic method, such as [Create Case](/docs/shared_services/supportapi/methods/create_case) or [Add Note](/docs/shared_services/supportapi/methods/add_note), completed only partially:
     * A case is successfully created but the subsequent call to retrieve all the case details fails. The error message will include a reference to (an identifier of) the case created in Support Portal.
 
 ### Examples

--- a/content/en/docs/shared_services/supportapi/formats/get_case_res.md
+++ b/content/en/docs/shared_services/supportapi/formats/get_case_res.md
@@ -13,22 +13,22 @@ description: Response format for the Get Case method.
 | caseNumber    | string                        |       no | Business identifier assigned to this case. |
 | subject       | string                        |       no | Brief description of this case. |
 | status        | string                        |       no | The current status of this case. |
-| createdDate   | string                        |       no | Date and time of case creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| modifiedDate  | string                        |       no | Date and time of the latest update. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| closedDate    | string                        |      yes | Date and time of case closure. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| severity      | [Severity](../severity)       |       no | The severity level calculated for this case. |
-| impact        | [Impact](../impact)           |      yes | Impact level. |
-| urgency       | [Urgency](../urgency)         |      yes | Urgency level. |
+| createdDate   | string                        |       no | Date and time of case creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| modifiedDate  | string                        |       no | Date and time of the latest update. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| closedDate    | string                        |      yes | Date and time of case closure. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| severity      | [Severity](/docs/shared_services/supportapi/formats/severity)       |       no | The severity level calculated for this case. |
+| impact        | [Impact](/docs/shared_services/supportapi/formats/impact)           |      yes | Impact level. |
+| urgency       | [Urgency](/docs/shared_services/supportapi/formats/urgency)         |      yes | Urgency level. |
 | account       | [Account](#account)           |       no | Details of the Axway customer account that case is registered with. |
 | contact       | [Contact](#contact)           |       no | Current contact for this case. |
 | owner         | [Contact](#contact)           |      yes | The current owner of this case. |
 | description   | string                        |       no | Detailed description of this case. |
-| environment   | [Environment](../environment) |       no | Environment for which this case is created. |
+| environment   | [Environment](/docs/shared_services/supportapi/formats/environment) |       no | Environment for which this case is created. |
 | notes         | [ [CaseNote](#casenote) ]     |      yes | List of all case notes attached to this case. |
 | product       | [Product](#product)           |       no | Product for which this case was created. |
 | attachments   | [ [Attachment](#attachment) ] |      yes | Summary information about the files attached to this case. |
 | ccEmails      | [ string ]                    |      yes | E-mail addresses copied in communications regarding this case. |
-| type          | [CaseType](../case_type)      |       no | The type of this case. |
+| type          | [CaseType](/docs/shared_services/supportapi/formats/case_type)      |       no | The type of this case. |
 | customerEnhancementRequest | [CustomerEnhancementRequest](#customerenhancementrequest) | no | Present if and only if this case is an Enhancement Request and any related details are available. |
 
 ### CustomerEnhancementRequest
@@ -86,7 +86,7 @@ An open-ended enumeration.
 |---------------|---------------------|----------|-------------|
 | id            | string              |       no | An identifier of this attachment. Attachment download requires this ID.|
 | name          | string              |       no | The name under which this attachment was added. |
-| createdDate   | string              |       no | Date and time of attachment creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
+| createdDate   | string              |       no | Date and time of attachment creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
 | createdBy     | [Contact](#contact) |      yes | Contact that added this attachment. |
 
 ### Account

--- a/content/en/docs/shared_services/supportapi/formats/list_cases_req.md
+++ b/content/en/docs/shared_services/supportapi/formats/list_cases_req.md
@@ -19,8 +19,8 @@ description: Request format for the List Cases method.
 
 | Property Name | Data Type | Optional | Description |
 |---------------|-----------|----------|-------------|
-| before        | string    |       no | Starting date/time of the time span. [Format](../miscellaneous#common-date-and-time-format-for-requests). |
-| after         | string    |       no | Ending date/time of the time span. [Format](../miscellaneous#common-date-and-time-format-for-requests). |
+| before        | string    |       no | Starting date/time of the time span. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-requests). |
+| after         | string    |       no | Ending date/time of the time span. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-requests). |
 
 ### IncludeCaseTypes
 

--- a/content/en/docs/shared_services/supportapi/formats/list_cases_res.md
+++ b/content/en/docs/shared_services/supportapi/formats/list_cases_res.md
@@ -22,8 +22,8 @@ description: Response format for the List Cases method.
 | caseNumber    | string                   |       no | Business identifier assigned to this case. |
 | subject       | string                   |       no | Brief description of this case. |
 | status        | string                   |       no | The current status of this case. |
-| severity      | [Severity](../severity)  |       no | The severity level calculated for this case. |
-| createdDate   | string                   |       no | Date and time of case creation. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| modifiedDate  | string                   |       no | Date and time of the latest update. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| closedDate    | string                   |      yes | Date and time of case closure. [Format](../miscellaneous#common-date-and-time-format-for-responses). |
-| type          | [CaseType](../case_type) |       no | The type of this case. |
+| severity      | [Severity](/docs/shared_services/supportapi/formats/severity)  |       no | The severity level calculated for this case. |
+| createdDate   | string                   |       no | Date and time of case creation. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| modifiedDate  | string                   |       no | Date and time of the latest update. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| closedDate    | string                   |      yes | Date and time of case closure. [Format](/docs/shared_services/supportapi/formats/miscellaneous/#common-date-and-time-format-for-responses). |
+| type          | [CaseType](/docs/shared_services/supportapi/formats/case_type) |       no | The type of this case. |

--- a/content/en/docs/shared_services/supportapi/methods/add_note.md
+++ b/content/en/docs/shared_services/supportapi/methods/add_note.md
@@ -12,7 +12,7 @@ description: Add a note to an existing Axway Support case.
 
 **HTTP verb**: `POST`
 
-Add Note requests come in two forms: [simple](#add-note---simple) and [full](#add-note---full).
+Add Note requests come in two forms: [simple](#add-note-simple) and [full](#add-note-full).
 Simple requests allow you to send just the note information. Full requests allow you to attach files.
 
 ### Add Note - Simple
@@ -25,7 +25,7 @@ Send the note information directly as the HTTP entity-body.
 
 | Name | Type | Data Type                                       | Required | Allow Multiple | Description |
 |------|------|-------------------------------------------------|----------|----------------|-------------|
-| n/a  | body | [CaseNote](../../formats/add_note_req#casenote) |      yes |             no | Details of the note to be added. |
+| n/a  | body | [CaseNote](/docs/shared_services/supportapi/formats/add_note_req/#casenote) |      yes |             no | Details of the note to be added. |
 
 **Example**:
 
@@ -47,7 +47,7 @@ Each part of the request entity must contain a Content-Disposition header field.
 
 | Name        | Type      | Data Type                                        | Required | Allow Multiple | Description |
 |-------------|-----------|--------------------------------------------------|----------|----------------|-------------|
-| initializer | body part | [CaseNote](../../formats/add_note_req#casenote)  |      yes |             no | Details of the case to be created. |
+| initializer | body part | [CaseNote](/docs/shared_services/supportapi/formats/add_note_req/#casenote)  |      yes |             no | Details of the case to be created. |
 | attachment  | body part | file                                             |       no |            yes | File to attach to the case. |
 
 Constraints:
@@ -105,7 +105,7 @@ Add note with attachments example.
 
 | Type | Data Type                                       | Description |
 |------|-------------------------------------------------|-------------|
-| body | [CaseNote](../../formats/add_note_res#casenote) | Details of the added note. |
+| body | [CaseNote](/docs/shared_services/supportapi/formats/add_note_res/#casenote) | Details of the added note. |
 
 ### Unsuccessful responses
 
@@ -113,4 +113,4 @@ Add note with attachments example.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/close_case.md
+++ b/content/en/docs/shared_services/supportapi/methods/close_case.md
@@ -20,7 +20,7 @@ The affected case is marked closed and not deleted from our systems.
 
 | Name | Type | Data Type                                         | Required | Allow Multiple | Description |
 | -----|------|---------------------------------------------------|----------|----------------|-------------|
-| n/a  | body | [CaseNote](../../formats/close_case_req#casenote) |      yes |             no | Details required for case closure. |
+| n/a  | body | [CaseNote](/docs/shared_services/supportapi/formats/close_case_req/#casenote) |      yes |             no | Details required for case closure. |
 
 **Example**:
 
@@ -40,7 +40,7 @@ The affected case is marked closed and not deleted from our systems.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ [Case](../../formats/close_case_res#case) ] | Details of the closed case. |
+| body | [ [Case](/docs/shared_services/supportapi/formats/close_case_res/#case) ] | Details of the closed case. |
 
 ### Unsuccessful responses
 
@@ -48,4 +48,4 @@ The affected case is marked closed and not deleted from our systems.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/create_case.md
+++ b/content/en/docs/shared_services/supportapi/methods/create_case.md
@@ -12,7 +12,7 @@ description: Create a new support case or customer enhancement request.
 
 **HTTP verb**: `POST`
 
-Create Case requests come in two forms: [simple](#create-case---simple) and [full](#create-case---full).
+Create Case requests come in two forms: [simple](#create-case-simple) and [full](#create-case-full).
 Simple requests allow you to send just the case information. Full requests allow you to attach files.
 
 ### Create Case - Simple
@@ -25,7 +25,7 @@ Send the case information directly as the HTTP entity-body.
 
 | Name | Type | Data Type                                  | Required | Allow Multiple | Description |
 |------|------|--------------------------------------------|----------|----------------|-------------|
-| n/a  | body | [Case](../../formats/create_case_req#case) |      yes |             no | Details of the case to be created. |
+| n/a  | body | [Case](/docs/shared_services/supportapi/formats/create_case_req/#case) |      yes |             no | Details of the case to be created. |
 
 **Example**:
 
@@ -57,7 +57,7 @@ Send the case information directly as the HTTP entity-body.
 
 Allows for optionally attaching files at the time of case creation.
 {{% alert title="Note" %}}
-Files can be attached to an existing case at any time, by [adding](../add_note#add-note---full) a case note.
+Files can be attached to an existing case at any time, by [adding](/docs/shared_services/supportapi/methods/add_note/#add-note-full) a case note.
 {{% /alert %}}
 
 **Consumes**: multipart/form-data
@@ -68,7 +68,7 @@ Each part of the request entity must contain a Content-Disposition header field.
 
 | Name        | Type      | Data Type                                  | Required | Allow Multiple | Description |
 |-------------|-----------|--------------------------------------------|----------|----------------|-------------|
-| initializer | body part | [Case](../../formats/create_case_req#case) |      yes |             no | Details of the case to be created. |
+| initializer | body part | [Case](/docs/shared_services/supportapi/formats/create_case_req/#case) |      yes |             no | Details of the case to be created. |
 | attachment  | body part | file                                       |       no |            yes | File to attach to the case. |
 
 Constraints:
@@ -142,7 +142,7 @@ Create case with attachments example.
 
 | Type | Data Type                                  | Description |
 |------|--------------------------------------------|-------------|
-| body | [Case](../../formats/create_case_res#case) | Details of the created case. |
+| body | [Case](/docs/shared_services/supportapi/formats/create_case_res/#case) | Details of the created case. |
 
 {{% alert title="Note" %}}
 Some details, such as case severity, are automatically generated in our systems.
@@ -154,4 +154,4 @@ Some details, such as case severity, are automatically generated in our systems.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/download_attachment.md
+++ b/content/en/docs/shared_services/supportapi/methods/download_attachment.md
@@ -20,7 +20,7 @@ description: Download files attached to a specific support case or a support cas
 | attachmentId | query | string    |      yes |             no | ID of the attachment to be downloaded. |
 
 {{% alert title="Note" %}}
-Attachment identifiers can be obtained with a call to the [Get Case](../get_case) method. In the latter method's [response](../../formats/get_case_res#case), files that are attached directly to cases are described under `attachments`. Files that are attached to notes are described under  `noteAttachments`, nested within their respective note, nested within `notes`.
+Attachment identifiers can be obtained with a call to the [Get Case](/docs/shared_services/supportapi/methods/get_case) method. In the latter method's [response](/docs/shared_services/supportapi/formats/get_case_res/#case), files that are attached directly to cases are described under `attachments`. Files that are attached to notes are described under  `noteAttachments`, nested within their respective note, nested within `notes`.
 {{% /alert %}}
 
 ## Response
@@ -48,4 +48,4 @@ Example: `Content-Disposition: attachment; filename=EXAMPLE.TXT`.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/get_accounts.md
+++ b/content/en/docs/shared_services/supportapi/methods/get_accounts.md
@@ -20,7 +20,7 @@ description: Get all support accounts associated with the authenticated user.
 
 | Type | Data Type                                             | Description |
 |------|-------------------------------------------------------|-------------|
-| body | [ [Account](../../formats/get_accounts_res#account) ] | List of accounts for which the authenticated user can open new or access existing support cases. |
+| body | [ [Account](/docs/shared_services/supportapi/formats/get_accounts_res/#account) ] | List of accounts for which the authenticated user can open new or access existing support cases. |
 
 ### Examples
 
@@ -43,4 +43,4 @@ description: Get all support accounts associated with the authenticated user.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/get_case.md
+++ b/content/en/docs/shared_services/supportapi/methods/get_case.md
@@ -26,7 +26,7 @@ description: Get the details of an existing Axway Support case.
 
 | Type | Data Type                                   | Description |
 |------|---------------------------------------------|-------------|
-| body | [ [Case](../../formats/get_case_res#case) ] | Detailed case information. |
+| body | [ [Case](/docs/shared_services/supportapi/formats/get_case_res/#case) ] | Detailed case information. |
 
 ### Examples
 
@@ -86,4 +86,4 @@ description: Get the details of an existing Axway Support case.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/get_products.md
+++ b/content/en/docs/shared_services/supportapi/methods/get_products.md
@@ -26,7 +26,7 @@ description: Get all products associated with a support account.
 
 | Type | Data Type                                             | Description |
 |------|-------------------------------------------------------|-------------|
-| body | [ [Product](../../formats/get_products_res#product) ] | List of products for the specified support access code. |
+| body | [ [Product](/docs/shared_services/supportapi/formats/get_products_res/#product) ] | List of products for the specified support access code. |
 
 ### Examples
 
@@ -169,4 +169,4 @@ description: Get all products associated with a support account.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |

--- a/content/en/docs/shared_services/supportapi/methods/list_cases.md
+++ b/content/en/docs/shared_services/supportapi/methods/list_cases.md
@@ -23,7 +23,7 @@ description: List cases, business service requests and customer enhancement requ
 
 #### query
 
-Allows you to retrieve only the desired information. Format: [Filter](../../formats/list_cases_req#filter).
+Allows you to retrieve only the desired information. Format: [Filter](/docs/shared_services/supportapi/formats/list_cases_req/#filter).
 
 To apply filtering, construct a JSON object per the format above, [percent-encode](https://tools.ietf.org/html/rfc3986#section-2.1) it and set the result as the value of the query parameter.
 
@@ -173,7 +173,7 @@ Please note that the default ordering is unspecified and can vary over time.
 
 | Type | Data Type                                   | Description |
 |------|---------------------------------------------|-------------|
-| body | [Cases](../../formats/list_cases_res#cases) | Cases matching the specified filter criteria. |
+| body | [Cases](/docs/shared_services/supportapi/formats/list_cases_res/#cases) | Cases matching the specified filter criteria. |
 
 ### Unsuccessful responses
 
@@ -181,4 +181,4 @@ Please note that the default ordering is unspecified and can vary over time.
 
 | Type | Data Type                                     | Description |
 |------|-----------------------------------------------|-------------|
-| body | [ErrorResponse](../../formats/error_response) | Details of the error that occurred. |
+| body | [ErrorResponse](/docs/shared_services/supportapi/formats/error_response) | Details of the error that occurred. |


### PR DESCRIPTION
## Describe the changes

Absolute paths(ex. /a/b/c) are now used instead of directory traversal(ex. ../b/c) ones
Fixed broken URIs that used double hyphens instead of single ones(ex. #add-note---simple is now #add-note-simple)

## Checklist for contributors

Before submitting this PR, please make sure:

* [X] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [X] You have verified the technical accuracy of your change
* [X] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [X] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
