### PR TITLE
RDAPI-20218 Add two new properties to promotion.properties file

### DIFF
--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -104,6 +104,8 @@ The promotion properties are described as follows:
 | `application.oauthresource.upgrade` | Specify whether to promote an existing OAuth resource if there is a conflict in the consumer organization (`true` or `false`). |
 | `api.publish.virtualhost`           | Specify an optional virtual host name and port on which the promoted APIs are available. The host name should be DNS resolvable. |
 | `api.unpublished.remove`            | Specify whether to remove an old unpubished API from the development organization (`true` or `false`). This only applies when an upgrade occurs. For example, if there is a conflict and `api.conflict.upgrade` is set to `true`, this results in two APIs (existing and upgraded). The `api.unpublished.remove` option specifies whether to keep or delete the existing API that has been unpublished. |
+| `application.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to applications should be removed (`true` or `false`), requires that `api.conflict.upgrade` be set to `true` also.|
+| `organization.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to organizations should be removed (`true` or `false`), requires that `api.conflict.upgrade` be set to `true` also.|
 
 After running the `apimanager-promote` command, press **F5** to reload the API Manager web console in the target environment.
 

--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -104,8 +104,8 @@ The promotion properties are described as follows:
 | `application.oauthresource.upgrade` | Specify whether to promote an existing OAuth resource if there is a conflict in the consumer organization (`true` or `false`). |
 | `api.publish.virtualhost`           | Specify an optional virtual host name and port on which the promoted APIs are available. The host name should be DNS resolvable. |
 | `api.unpublished.remove`            | Specify whether to remove an old unpubished API from the development organization (`true` or `false`). This only applies when an upgrade occurs. For example, if there is a conflict and `api.conflict.upgrade` is set to `true`, this results in two APIs (existing and upgraded). The `api.unpublished.remove` option specifies whether to keep or delete the existing API that has been unpublished. |
-| `application.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to applications should be removed (`true` or `false`), requires that `api.conflict.upgrade` be set to `true` also.|
-| `organization.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to organizations should be removed (`true` or `false`), requires that `api.conflict.upgrade` be set to `true` also.|
+| `application.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to applications should be removed (`true` or `false`). When enabled, requires that api.conflict.upgrade is set to true also.|
+| `organization.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to organizations should be removed (`true` or `false`). When enabled, requires that api.conflict.upgrade is set to true also.|
 
 After running the `apimanager-promote` command, press **F5** to reload the API Manager web console in the target environment.
 

--- a/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
+++ b/content/en/docs/apim_administration/apimgr_admin/api_mgmt_promote.md
@@ -104,8 +104,8 @@ The promotion properties are described as follows:
 | `application.oauthresource.upgrade` | Specify whether to promote an existing OAuth resource if there is a conflict in the consumer organization (`true` or `false`). |
 | `api.publish.virtualhost`           | Specify an optional virtual host name and port on which the promoted APIs are available. The host name should be DNS resolvable. |
 | `api.unpublished.remove`            | Specify whether to remove an old unpubished API from the development organization (`true` or `false`). This only applies when an upgrade occurs. For example, if there is a conflict and `api.conflict.upgrade` is set to `true`, this results in two APIs (existing and upgraded). The `api.unpublished.remove` option specifies whether to keep or delete the existing API that has been unpublished. |
-| `application.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to applications should be removed (`true` or `false`). When enabled, requires that api.conflict.upgrade is set to true also.|
-| `organization.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to organizations should be removed (`true` or `false`). When enabled, requires that api.conflict.upgrade is set to true also.|
+| `application.apis.remove.all`       | Specifies whether, on API conflict, all current API access granted to applications should be removed (`true` or `false`). When enabled, requires that api.conflict.upgrade is set to `true` also.|
+| `organization.apis.remove.all`      | Specifies whether, on API conflict, all current API access granted to organizations should be removed (`true` or `false`). When enabled, requires that api.conflict.upgrade is set to `true` also.|
 
 After running the `apimanager-promote` command, press **F5** to reload the API Manager web console in the target environment.
 


### PR DESCRIPTION
Updating the api_mgmt_promote to document new properties added to the apimanager-promote script:

- application.apis.remove.all  added by https://jira.axway.com/browse/RDAPI-20218.
- organization.apis.remove.all added by https://jira.axway.com/browse/RDAPI-20829

https://deploy-preview-1419--axway-open-docs.netlify.app/docs/apim_administration/apimgr_admin/api_mgmt_promote/

