### PR TITLE
RDAPI-22573 Update Jan21 Known issues

### DIFF
--- a/content/en/docs/apim_relnotes/20210130_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20210130_apimgr_relnotes.md
@@ -69,7 +69,7 @@ The following are known issues for this update.
 
 | Internal ID | Description                                                                                                                                                                                                                                                                                                                                   |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| RDAPI-22573 | **Issue**: Service pack update fails with the following message when passphrases are in use: `"Problem connecting to store:  Invalid passphrase for configuration"`. **Workaround**: Wait for the purge task which runs every 10 minutes on the NodeManager process, to remove old gateway configurations before starting the update process. |
+| RDAPI-22573 | Service pack update fails with the following message when passphrases are in use: `"Problem connecting to store: Invalid passphrase for configuration"`. |
 
 ## Update a classic (non-container) deployment
 

--- a/content/en/docs/apim_relnotes/20210130_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20210130_apimgr_relnotes.md
@@ -67,7 +67,9 @@ placeholder
 
 The following are known issues for this update.
 
-placeholder
+| Internal ID | Description                                                                                                                                                                                                                                                                                                                                   |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RDAPI-22573 | **Issue**: Service pack update fails with the following message when passphrases are in use: `"Problem connecting to store:  Invalid passphrase for configuration"`. **Workaround**: Wait for the purge task which runs every 10 minutes on the NodeManager process, to remove old gateway configurations before starting the update process. |
 
 ## Update a classic (non-container) deployment
 


### PR DESCRIPTION
https://deploy-preview-1582--axway-open-docs.netlify.app/docs/apim_relnotes/20210130_apimgr_relnotes/

Added RDAPI-22573 issue and workaround to Jan21 release notes.