### PR TITLE
RDAPI-22806 Documentation for Passphrase Password Policy

### DIFF
--- a/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
+++ b/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
@@ -196,7 +196,9 @@ To configure the password policy that applies to admin user passwords, perform t
 
 ### Configure a passphrase policy for Node Managers and API Gateway Groups
 
-To configure the passphrase policy that applies to the passphrases of Node Managers and API Gateway groups perform the following steps as an API Server Administrator:
+Please note that it is currently not possible to configure a passphrase policy for Node Managers and API Gateway Groups through the UI. Instead an API Server Administrator must configure the passphrase policy by calling `/topology/passphrasepolicy` API's. The product ships with the passphrase policy disabled.
+
+To configure a passphrase policy that applies to the passphrases of Node Managers and API Gateway groups perform the following steps as an API Server Administrator:
 
 1. Call method `GET /topology/passphrasepolicy` of the [API Gateway API v1.0 Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy) to get the current passphrase policy.
 2. Update the configurations returned from the API call to meet your specifications.

--- a/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
+++ b/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
@@ -196,15 +196,16 @@ To configure the password policy that applies to admin user passwords, perform t
 
 ### Configure a passphrase policy for admin users
 
-To configure the passphrase policy that applies to nodemanager and group passphrases, perform the following steps as an API Gateway Manager administrator:
+To configure the passphrase policy that applies to the node manager and group passphrases, perform the following steps as an API Gateway Manager administrator:
 
-1. Call the following API to [get the current passphrase policy](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy).
-2. Edit the configurations returned from the previous API call to meet your specifications.
-3. Paste the new configurations into the body of the following API to [update your passphrase policy](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/put_topology_passphrasepolicy). Ensure enabled is set to true at the top of the body in the request to enable the passphrase policy.
+1. Call method `GET /topology/passphrasepolicy` of the [API Gateway API v1.0 Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy) to get the current passphrase policy.
+2. Update the configurations returned from the API call to meet your specifications.
+3. Paste the new configurations into the body of the `/topology/passphrasepolicy` method, in the same [Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/put_topology_passphrasepolicy), to update your passphrase policy.
+4. Ensure **enabled** is set to true at the top of the body in the request to enable the passphrase policy.
 
-Sample body, including all available configurations, for updating passphrase policy:
+The following is a sample body, including all available configurations for updating the passphrase policy:
 
-```
+```json
 {
   "enabled" : true,
   "assertions" : [ {
@@ -257,7 +258,7 @@ Sample body, including all available configurations, for updating passphrase pol
     }, {
       "enabled" : true,
       "resourceID" : "MUST_HAVE_LOWER_CASE",
-      "name" : "Must contain an lower case character",
+      "name" : "Must contain a lower case character",
       "count" : "1"
     }, {
       "enabled" : true,

--- a/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
+++ b/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
@@ -194,14 +194,13 @@ To configure the password policy that applies to admin user passwords, perform t
     * If no value is specified in these fields, these rules are disabled.
 5. Click **Apply** when finished.
 
-### Configure a passphrase policy for admin users
+### Configure a passphrase policy for Node Managers and API Gateway Groups
 
-To configure the passphrase policy that applies to the node manager and group passphrases, perform the following steps as an API Gateway Manager administrator:
+To configure the passphrase policy that applies to the passphrases of Node Managers and API Gateway groups perform the following steps as an API Server Administrator:
 
 1. Call method `GET /topology/passphrasepolicy` of the [API Gateway API v1.0 Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy) to get the current passphrase policy.
 2. Update the configurations returned from the API call to meet your specifications.
-3. Paste the new configurations into the body of the `/topology/passphrasepolicy` method, in the same [Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/put_topology_passphrasepolicy), to update your passphrase policy.
-4. Ensure **enabled** is set to true at the top of the body in the request to enable the passphrase policy.
+3. Paste the new configurations into the body of the `PUT /topology/passphrasepolicy` method, in the same [Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/put_topology_passphrasepolicy), to update your passphrase policy.
 
 The following is a sample body, including all available configurations for updating the passphrase policy:
 
@@ -272,9 +271,6 @@ The following is a sample body, including all available configurations for updat
       "name" : "Must contain a special character",
       "count" : "1"
     } ]
-  } ],
-  "version" : 2,
-  "dataVersion" : "7.7.0",
-  "timestamp" : 1613035792336
+  } ]
 }
 ```

--- a/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
+++ b/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
@@ -193,3 +193,87 @@ To configure the password policy that applies to admin user passwords, perform t
     * **Minimum special characters**: Defaults to 1 special character (`~!@#$%^&*()-_=+\[{}];:"",< >/?`).
     * If no value is specified in these fields, these rules are disabled.
 5. Click **Apply** when finished.
+
+### Configure a passphrase policy for admin users
+
+To configure the passphrase policy that applies to nodemanager and group passphrases, perform the following steps as an API Gateway Manager administrator:
+
+1. Call the following API to [get the current passphrase policy](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy).
+2. Edit the configurations returned from the previous API call to meet your specifications.
+3. Paste the new configurations into the body of the following API to [update your passphrase policy](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/put_topology_passphrasepolicy). Ensure enabled is set to true at the top of the body in the request to enable the passphrase policy.
+
+Sample body, including all available configurations, for updating passphrase policy:
+
+```
+{
+  "enabled" : true,
+  "assertions" : [ {
+    "description" : "general",
+    "matchCount" : "*",
+    "enabled" : true,
+    "assertion" : [ {
+      "enabled" : true,
+      "resourceID" : "PASSWORD_NOT_NULL",
+      "name" : "Passphrase cannot be empty"
+    }, {
+      "enabled" : true,
+      "resourceID" : "PASSWORD_MIN_LENGTH",
+      "minLength" : "4",
+      "name" : "Passphrase must be longer than N characters"
+    }, {
+      "enabled" : true,
+      "resourceID" : "PASSWORD_NOT_EQUAL_TO_ACC_NAME",
+      "name" : "Passphrase cannot be the same as the domain/node manager/group name"
+    }, {
+      "enabled" : true,
+      "resourceID" : "PASSWORD_NOT_EQUAL_TO_REV_ACC_NAME",
+      "name" : "Passphrase cannot be the same as the reverse of domain/node manager/group name"
+    }, {
+      "enabled" : false,
+      "resourceID" : "PASSWORD_NOT_CONTAINING_ACC_NAME",
+      "name" : "Passphrase cannot contain domain/node manager/group name"
+    }, {
+      "enabled" : false,
+      "resourceID" : "PASSWORD_DISTANCE",
+      "name" : "Passphrase Distance"
+    }, {
+      "enabled" : false,
+      "resourceID" : "PASSWORD_LIFETIME",
+      "name" : "Passphrase Lifetime"
+    }, {
+      "enabled" : false,
+      "resourceID" : "PASSWORD_NOT_IN_HISTORY",
+      "name" : "Passphrase not in history"
+    } ]
+  }, {
+    "description" : "composition",
+    "matchCount" : "*",
+    "enabled" : true,
+    "assertion" : [ {
+      "enabled" : true,
+      "resourceID" : "MUST_HAVE_UPPER_CASE",
+      "name" : "Must contain an upper case character",
+      "count" : "1"
+    }, {
+      "enabled" : true,
+      "resourceID" : "MUST_HAVE_LOWER_CASE",
+      "name" : "Must contain an lower case character",
+      "count" : "1"
+    }, {
+      "enabled" : true,
+      "resourceID" : "MUST_CONTAIN_DIGIT",
+      "name" : "Must contain a number",
+      "count" : "1"
+    }, {
+      "enabled" : true,
+      "characters" : "~!@#$%^&*()-_=+\\|[{}];:'\",<.>/ ?",
+      "resourceID" : "MUST_CONTAIN_SPECIAL_CHARACTERS",
+      "name" : "Must contain a special character",
+      "count" : "1"
+    } ]
+  } ],
+  "version" : 2,
+  "dataVersion" : "7.7.0",
+  "timestamp" : 1613035792336
+}
+```

--- a/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
+++ b/content/en/docs/apim_administration/apigtw_admin/manage_user_access.md
@@ -22,21 +22,10 @@ You can create gateway users on the **Users** page. Click the **Add** button on 
 
 To specify the new user details, complete the following fields on the **General** tab:
 
-**User Name**:
-
-Enter a name for the new user.
-
-**Password**:
-
-Enter a password for the new user.
-
-**Confirm Password**:
-
-Re-enter the user's password to confirm.
-
-**Signing Key**:
-
-Click to load the user certificate from the **Certificate Store**. For details on how to create and import certificates, see [Manage certificates and keys](/docs/apim_administration/apigtw_admin/general_certificates/).
+* **User Name**: Enter a name for the new user.
+* **Password**: Enter a password for the new user.
+* **Confirm Password**: Re-enter the user's password to confirm.
+* **Signing Key**: Click to load the user certificate from the **Certificate Store**. For details on how to create and import certificates, see [Manage certificates and keys](/docs/apim_administration/apigtw_admin/general_certificates/).
 
 You can also specify optional user attributes on the **Attributes** tab, which is explained in the next section.
 
@@ -194,13 +183,11 @@ To configure the password policy that applies to admin user passwords, perform t
     * If no value is specified in these fields, these rules are disabled.
 5. Click **Apply** when finished.
 
-### Configure a passphrase policy for Node Managers and API Gateway Groups
+## Configure a passphrase policy for node managers and API Gateway groups
 
-Please note that it is currently not possible to configure a passphrase policy for Node Managers and API Gateway Groups through the UI. Instead an API Server Administrator must configure the passphrase policy by calling `/topology/passphrasepolicy` API's. The product ships with the passphrase policy disabled.
+To configure a [passphrase policy](/docs/apimgmt_security/c_secgd_bp_intro/#passphrase-policy) that applies to the passphrases of node managers and API Gateway groups perform the following steps as an API Server Administrator:
 
-To configure a passphrase policy that applies to the passphrases of Node Managers and API Gateway groups perform the following steps as an API Server Administrator:
-
-1. Call method `GET /topology/passphrasepolicy` of the [API Gateway API v1.0 Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy) to get the current passphrase policy.
+1. Call the `GET /topology/passphrasepolicy` method of the [API Gateway API v1.0 Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/get_topology_passphrasepolicy) to get the current passphrase policy. The passphrase policy is disabled by default.
 2. Update the configurations returned from the API call to meet your specifications.
 3. Paste the new configurations into the body of the `PUT /topology/passphrasepolicy` method, in the same [Topology API](http://apidocs.axway.com/swagger-ui/index.html?productname=apigateway&productversion=7.7.0&filename=api-gateway-swagger.json#!/Topology_API/put_topology_passphrasepolicy), to update your passphrase policy.
 
@@ -276,3 +263,5 @@ The following is a sample body, including all available configurations for updat
   } ]
 }
 ```
+
+{{% alert title="Note" %}}Configuring a passphrase policy is currently not possible by way of API Manager UI.{{% /alert %}}

--- a/content/en/docs/apim_reference/config_files_reference.md
+++ b/content/en/docs/apim_reference/config_files_reference.md
@@ -195,6 +195,14 @@ This file is edited through the UI, but it can be changed manually. Configures r
 apigateway/conf/passwordPolicy.json
 ```
 
+## passphrasePolicy.json
+
+This file is edited though an API call, but it can be changed manually. Configures rules around passphrase requirements for nodemanagers and groups.
+
+```
+apigateway/conf/passphrasePolicy.json
+```
+
 ## userconfig.dtd for Node Manager
 
 User configurations for Node Manager.

--- a/content/en/docs/apim_reference/config_files_reference.md
+++ b/content/en/docs/apim_reference/config_files_reference.md
@@ -197,7 +197,7 @@ apigateway/conf/passwordPolicy.json
 
 ## passphrasePolicy.json
 
-This file is edited though an API call, but it can be changed manually. Configures rules around passphrase requirements for nodemanagers and groups.
+This file is edited though an API call, but it can be changed manually. Configures rules around passphrase requirements for Node Managers and API Gateway groups.
 
 ```
 apigateway/conf/passphrasePolicy.json

--- a/content/en/docs/apim_reference/config_files_reference.md
+++ b/content/en/docs/apim_reference/config_files_reference.md
@@ -16,9 +16,9 @@ Contains settings for redaction.
 apigateway/system/conf/redaction.xml
 ```
 
-## Node Manager entity store
+## Node manager entity store
 
-The following directory contains the entity store configuration for Node Manager.
+The following directory contains the entity store configuration for node manager.
 
 ```
 apigateway/conf/fed
@@ -131,9 +131,9 @@ sso.jks
 idp.xml
 ```
 
-## ACL and roles for Node Manager management APIs
+## ACL and roles for node manager management APIs
 
-Used to edit the Access Control List roles for Node Manager management APIs.
+Used to edit the Access Control List roles for node manager management APIs.
 
 ```
 apigateway/conf/acl.json
@@ -155,9 +155,9 @@ A series of rules to control entry to the domain audit log.
 apigateway/conf/apiaudit.xml
 ```
 
-## envSettings.props for Node Manager
+## envSettings.props for node manager
 
-Environment settings for Node Manager, such as host and port information.
+Environment settings for node manager, such as host and port information.
 
 ```
 apigateway/conf/envSettings.props
@@ -181,7 +181,7 @@ apigateway/conf/managedomain.props
 
 ## openssl.cnf
 
-Used for creating the default certs in the Node Manager. Contains the list of predefined variables for the cert.
+Used for creating the default certs in the node manager. Contains the list of predefined variables for the cert.
 
 ```
 apigateway/conf/openssl.cnf
@@ -189,7 +189,7 @@ apigateway/conf/openssl.cnf
 
 ## passwordPolicy.json
 
-This file is edited through the UI, but it can be changed manually. Configures rules around password requirements.
+Used for configuring rules around password requirements. You can edit this file through the UI, or using an editor of your choice.
 
 ```
 apigateway/conf/passwordPolicy.json
@@ -197,15 +197,15 @@ apigateway/conf/passwordPolicy.json
 
 ## passphrasePolicy.json
 
-This file is edited though an API call, but it can be changed manually. Configures rules around passphrase requirements for Node Managers and API Gateway groups.
+Used for configuring rules around passphrase requirements for node managers and API Gateway groups. You can edit this file through an API call, or using an editor of your choice.
 
 ```
 apigateway/conf/passphrasePolicy.json
 ```
 
-## userconfig.dtd for Node Manager
+## userconfig.dtd for node manager
 
-User configurations for Node Manager.
+User configurations for node manager.
 
 ```
 apigateway/conf/userconfig.dtd

--- a/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
+++ b/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
@@ -78,9 +78,9 @@ You can also configure password policies for [API Manager](/docs/apim_administra
 
 ## Passphrase policy
 
-In line with security best practices, an API Server Administrator can configure a passphrase policy for Node Managers and API Gateway groups. Passphrase policy refers to the size and complexity of the passphrase, as well as all the rules to manage the passphrases.
+In line with security best practices, an API Server Administrator can configure a passphrase policy for node managers and API Gateway groups. Passphrase policy refers to the size and complexity of the passphrase, as well as all the rules to manage the passphrases.
 
-For more information on setting the passphrase policy, see [Configure a passphrase policy for Node Managers and API Gateway Groups](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-node-managers-and-api-gateway-groups).
+For more information on setting the passphrase policy, see [Configure a passphrase policy for node managers and API Gateway groups](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-node-managers-and-api-gateway-groups).
 
 ## Default authentication account
 
@@ -148,7 +148,7 @@ The passwords are stored as a salted hash derived from 102400 iterations of the 
 The following file contains the hashed passphrases for Node Managers and API Gateway groups.
 
 ```
-/conf/groupSettings.json
+/system/conf/groupSettings.json
 ```
 
 The passphrases are stored as a salted hash derived from 102400 iterations of the PBKDF2 algorithm with HmacSHA-2. Each passphrase uses a different salt so that identical passphrases result in different stored hashes.

--- a/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
+++ b/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
@@ -76,6 +76,12 @@ For more information on setting the password policy for administrator users, see
 
 You can also configure password policies for [API Manager](/docs/apim_administration/apimgr_admin/api_mgmt_admin/#enforce-password-changes) and [API Portal](/docs/apim_administration/apiportal_admin/customize_page_content/#enforce-password-policies) users.
 
+## Passphrase policy
+
+In line with security best practices, an administrator for API Gateway Manager can configure a passphrase policy for nodemanagers and groups. Passphrase policy refers to the size and complexity of the passphrase, as well as all the rules to manage the passphrases.
+
+For more information on setting the passphrase policy for administrator users, see [Configure a passphrase policy for admin users](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-admin-users).
+
 ## Default authentication account
 
 The default behavior of the software version of the product is to force you to set an administrator password during installation.
@@ -134,6 +140,16 @@ The following file contains the hashed passwords of administrator users that hav
 ```
 /conf/adminUsers.json
 ```
+
+### Nodemanager and Group passphrases
+
+The following file contains the hashed passphrases for nodemanagers and groups.
+
+```
+/conf/groupSettings.json
+```
+
+The passphrases are stored as a salted hash derived from 102400 iterations of the PBKDF2 algorithm with HmacSHA-2. Each passphrase uses a different salt so that identical passphrases result in different stored hashes.
 
 The passwords are stored as a salted hash derived from 102400 iterations of the PBKDF2 algorithm with HmacSHA-2.  Each password uses a different salt so that identical passwords result in different stored hashes.
 

--- a/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
+++ b/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
@@ -78,9 +78,9 @@ You can also configure password policies for [API Manager](/docs/apim_administra
 
 ## Passphrase policy
 
-In line with security best practices, an administrator for API Gateway Manager can configure a passphrase policy for nodemanagers and groups. Passphrase policy refers to the size and complexity of the passphrase, as well as all the rules to manage the passphrases.
+In line with security best practices, an API Server Administrator can configure a passphrase policy for Node Managers and API Gateway groups. Passphrase policy refers to the size and complexity of the passphrase, as well as all the rules to manage the passphrases.
 
-For more information on setting the passphrase policy for administrator users, see [Configure a passphrase policy for admin users](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-admin-users).
+For more information on setting the passphrase policy, see [Configure a passphrase policy for Node Managers and API Gateway Groups](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-node-managers-and-api-gateway-groups).
 
 ## Default authentication account
 
@@ -141,9 +141,9 @@ The following file contains the hashed passwords of administrator users that hav
 /conf/adminUsers.json
 ```
 
-### Nodemanager and Group passphrases
+### Node Manager and API Gateway Group passphrases
 
-The following file contains the hashed passphrases for nodemanagers and groups.
+The following file contains the hashed passphrases for Node Managers and API Gateway groups.
 
 ```
 /conf/groupSettings.json

--- a/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
+++ b/content/en/docs/apimgmt_security/c_secgd_bp_intro.md
@@ -141,6 +141,8 @@ The following file contains the hashed passwords of administrator users that hav
 /conf/adminUsers.json
 ```
 
+The passwords are stored as a salted hash derived from 102400 iterations of the PBKDF2 algorithm with HmacSHA-2.  Each password uses a different salt so that identical passwords result in different stored hashes.
+
 ### Node Manager and API Gateway Group passphrases
 
 The following file contains the hashed passphrases for Node Managers and API Gateway groups.
@@ -150,8 +152,6 @@ The following file contains the hashed passphrases for Node Managers and API Gat
 ```
 
 The passphrases are stored as a salted hash derived from 102400 iterations of the PBKDF2 algorithm with HmacSHA-2. Each passphrase uses a different salt so that identical passphrases result in different stored hashes.
-
-The passwords are stored as a salted hash derived from 102400 iterations of the PBKDF2 algorithm with HmacSHA-2.  Each password uses a different salt so that identical passwords result in different stored hashes.
 
 ### Key Property Store
 

--- a/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
+++ b/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
@@ -204,7 +204,6 @@ API Portal forces a Joomla! administrator password change on first login.
 
 API Server Administrators can configure the following rules for Node Manager and API Gateway group passphrases:
 
-* Restrictions on using account user name in passphrase.
 * Restrictions on passphrase length.
 * Restrictions on using passphrases that are similar to passphrases used previously.
 * How long a passphrase is valid.

--- a/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
+++ b/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
@@ -200,9 +200,9 @@ You can set the administrator's password during installation.
 
 API Portal forces a Joomla! administrator password change on first login.
 
-## Nodemanager and group passphrase policy
+## Node Manager and API Gateway group passphrase policy
 
-You can configure the following rules for nodemanager and group passphrases for API Gateway administrators:
+API Server Administrators can configure the following rules for Node Manager and API Gateway group passphrases:
 
 * Restrictions on using account user name in passphrase.
 * Restrictions on passphrase length.
@@ -210,7 +210,7 @@ You can configure the following rules for nodemanager and group passphrases for 
 * How long a passphrase is valid.
 * The minimum number of uppercase, lowercase, numeric, and special characters a passphrase must contain.
 
-For more details, see [Configure a passphrase policy for admin users](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-admin-users).
+For more details, see [Configure a passphrase policy for Node Managers and API Gateway Groups](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-node-managers-and-api-gateway-groups).
 
 ## API Gateway signing the audit trail
 

--- a/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
+++ b/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
@@ -200,16 +200,16 @@ You can set the administrator's password during installation.
 
 API Portal forces a Joomla! administrator password change on first login.
 
-## Node Manager and API Gateway group passphrase policy
+## Node manager and API Gateway group passphrase policy
 
-API Server Administrators can configure the following rules for Node Manager and API Gateway group passphrases:
+API Server Administrators can configure the following rules for node manager and API Gateway group passphrases:
 
 * Restrictions on passphrase length.
 * Restrictions on using passphrases that are similar to passphrases used previously.
 * How long a passphrase is valid.
 * The minimum number of uppercase, lowercase, numeric, and special characters a passphrase must contain.
 
-For more details, see [Configure a passphrase policy for Node Managers and API Gateway Groups](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-node-managers-and-api-gateway-groups).
+For more information on setting the passphrase policy, see [Configure a passphrase policy for node managers and API Gateway groups](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-node-managers-and-api-gateway-groups).
 
 ## API Gateway signing the audit trail
 

--- a/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
+++ b/content/en/docs/apimgmt_security/c_secgd_config_secconfig.md
@@ -200,6 +200,18 @@ You can set the administrator's password during installation.
 
 API Portal forces a Joomla! administrator password change on first login.
 
+## Nodemanager and group passphrase policy
+
+You can configure the following rules for nodemanager and group passphrases for API Gateway administrators:
+
+* Restrictions on using account user name in passphrase.
+* Restrictions on passphrase length.
+* Restrictions on using passphrases that are similar to passphrases used previously.
+* How long a passphrase is valid.
+* The minimum number of uppercase, lowercase, numeric, and special characters a passphrase must contain.
+
+For more details, see [Configure a passphrase policy for admin users](/docs/apim_administration/apigtw_admin/manage_user_access/#configure-a-passphrase-policy-for-admin-users).
+
 ## API Gateway signing the audit trail
 
 An important aspect of maintaining the integrity of the product audit trail is the ability to sign audit records.  API Gateway can sign audit data written to text files, XML files, and databases.


### PR DESCRIPTION
Thank you for your contribution to the Axway-Open-Docs repo.

## Describe the changes

We now have the ability to set a passphrase policy for nodemanagers and groups. This is similar to how the current password policy works but we cannot edit the passphrase policy through the UI like the password policy. We can edit it through an API call which is recommended or manually.

## Deploy preview link

https://deploy-preview-1639--axway-open-docs.netlify.app/docs/apim_administration/apigtw_admin/manage_user_access/
https://deploy-preview-1639--axway-open-docs.netlify.app/docs/apim_reference/config_files_reference/
https://deploy-preview-1639--axway-open-docs.netlify.app/docs/apimgmt_security/c_secgd_bp_intro/
https://deploy-preview-1639--axway-open-docs.netlify.app/docs/apimgmt_security/c_secgd_config_secconfig/


_Although Netlify will add this link below, it will redirect to the main page of the documentation, not to an specific page._

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [x] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._
