### PR TITLE
[RDAPI-23063] Adding to May2020 release note for PS future releases bug

### DIFF
--- a/content/en/docs/apim_relnotes/20200530_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20200530_apimgr_relnotes.md
@@ -272,6 +272,7 @@ The following are known issues for this update.
 | RDAPI-16486 | Changes in the mapper always require a reload in the Execute Data Maps filter and once reloaded then providing values for the required parameters must be repeated |
 | RDAPI-15981 | Scopes fields for API Key remain visible even if Application Scopes are disabled                                                                                   |
 | RDAPI-11143 | Discrepancy with API retirements dates                                                                                                                             |
+| RDAPI-23063 | Policy Studio 2020 May release can open projects from future releases                                             |
 
 ### Policy Studio help documentation
 


### PR DESCRIPTION
Thank you for your contribution to the Axway-Open-Docs repo.

## Describe the changes

Adding one line to the known issues of the May 2020 release notes. 

RDAPI-23063 ticket found that May 2020 can open Policy Studio projects from future releases so we had to add it as a known issue.

## Deploy preview link

https://deploy-preview-1756--axway-open-docs.netlify.app/docs/apim_relnotes/20200530_apimgr_relnotes/#known-issues

## Checklist for contributors

Before submitting this PR, please make sure:

* [X] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [X] You have signed the [Axway CLA](https://cla.axway.com/)
* [X] You have verified the technical accuracy of your change
* [X] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [X] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [X] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._
