### PR TITLE
Update Connect to a database URL section with Example Setup for TLS with MySQL Server

### DIFF
--- a/content/en/docs/apim_installation/apigtw_install/metrics_db_install.md
+++ b/content/en/docs/apim_installation/apigtw_install/metrics_db_install.md
@@ -167,12 +167,19 @@ Latest schema version:002-leaf
 Schema successfully upgraded to:002-leaf
 ```
 
-{{< alert title="Example: Setup for TLS with MySQL Server" color="primary" >}}JDBC drivers can support additional parameters as part of the JDBC URL string. Which options are supported by a respective JDBC driver depends on the vendor and version.<p><p>In example, for **MySQL** the TLS parameters used by a client like API-Manager or Node-Manager to connect to a server can be enforced to make sure database connections will only be established if the database server offers the required capabilities.<p>
-More details can be found at MySQL Connector/J 5.1 Developer Guide [Connection URL Syntax](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-url-format.html) and [Configuration Properties for Connector/J - Security](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-connp-props-security.html).<p>
-The following example JDBC string illustrates TLS configuration for AWS RDS MySQL to require TLS 1.2, the server certificate must not be checked for a valid trust chain:<p>
+Example: Setup for TLS with MySQL Server.
+
+JDBC drivers can support additional parameters as part of the JDBC URL string. Which options are supported by a respective JDBC driver depends on the vendor and version.
+
+In a MySQL database, the TLS parameters used by a client, like API Manager or Node Manager, to connect to a server can be enforced to ensure that database connections will only be established if the database server offers the required capabilities.
+
+The following example JDBC string shows a TLS configuration for AWS RDS MySQL to require TLS 1.2. The server certificate must not be checked for a valid trust chain:
+
 ```
 jdbc:mysql://dba3s-np-rds-apimgateway-dev-int-mysql.cpqdyezqyf7p.eu-central-1.rds.amazonaws.com:3306/apimetrics?useSSL=true&requireSSL=true&verifyServerCertificate=false
-```{{< /alert >}}
+```
+
+For more information, see [Connection URL Syntax](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-url-format.html) and [Configuration Properties for Connector/J - Security](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-connp-props-security.html).
 
 #### Install a database
 

--- a/content/en/docs/apim_installation/apigtw_install/metrics_db_install.md
+++ b/content/en/docs/apim_installation/apigtw_install/metrics_db_install.md
@@ -1,11 +1,10 @@
 {
 "title": "Install and configure a metrics database",
-"linkTitle": "Install and configure a metrics database",
-"weight":"26",
-"date": "2019-10-07",
-"description": "Create and configure a database for monitoring in API Gateway Analytics, API Manager, and third-party tools."
+  "linkTitle": "Install and configure a metrics database",
+  "weight": "26",
+  "date": "2019-10-07",
+  "description": "Create and configure a database for monitoring in API Gateway Analytics, API Manager, and third-party tools."
 }
-
 API Gateway stores and maintains monitoring and transaction data in a JDBC-compliant database, which can be read by API Gateway Analytics, API Manager, and third-party monitoring tools.
 
 ## Prerequisites
@@ -43,8 +42,9 @@ You must add the JDBC driver files for your chosen third-party database to your 
 To add the third-party JDBC driver files for your database to API Gateway, perform the following steps:
 
 1. Add the binary files for your database driver as follows:
-    * Add `.jar` files to `INSTALL_DIR/apigateway/ext/lib`
-    * Add `.so` files to the `INSTALL_DIR/apigateway/platform/lib`
+
+   * Add `.jar` files to `INSTALL_DIR/apigateway/ext/lib`
+   * Add `.so` files to the `INSTALL_DIR/apigateway/platform/lib`
 2. Restart API Gateway.
 
 ### Add JDBC drivers to Policy Studio
@@ -130,16 +130,16 @@ When you specify command-line arguments to `dbsetup`, the script does not run in
 
 You can specify the following options to the `dbsetup` command:
 
-| Option                                   | Description    |
-|------------------------------------------|----------------|
-| `-h, --help`                             | Displays help message and exits. |
-| `-p PASSPHRASE, --passphrase=PASSPHRASE` | Specifies the configuration passphrase (blank for zero length). |
-| `--dbname=DBNAME`                        | Specifies the database name (mutually exclusive with `--dburl`,`--dbuser`, and `--dbpass`). |
-| `--dburl=DBURL`                          | Specifies the database URL. |
-| `--dbuser=DBUSER`                        | Specifies the database user. |
+| Option                                   | Description                                                                                                                                                                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-h, --help`                             | Displays help message and exits.                                                                                                                                                                                            |
+| `-p PASSPHRASE, --passphrase=PASSPHRASE` | Specifies the configuration passphrase (blank for zero length).                                                                                                                                                             |
+| `--dbname=DBNAME`                        | Specifies the database name (mutually exclusive with `--dburl`,`--dbuser`, and `--dbpass`).                                                                                                                                 |
+| `--dburl=DBURL`                          | Specifies the database URL.                                                                                                                                                                                                 |
+| `--dbuser=DBUSER`                        | Specifies the database user.                                                                                                                                                                                                |
 | `--dbpass=DBPASS`                        | Specifies the database password. You must enclose passwords that contain special characters in single quotation marks. For example: `./dbsetup --dburl=mysql://127.0.0.1:3306/reports --dbuser=root --dbpass='AcmeCorp!23'` |
-| `--reinstall`                            | Forces a reinstall of the database, dropping all data. |
-| `--stop=STOP`                            | Stops the database upgrade after the named upgrade. |
+| `--reinstall`                            | Forces a reinstall of the database, dropping all data.                                                                                                                                                                      |
+| `--stop=STOP`                            | Stops the database upgrade after the named upgrade.                                                                                                                                                                         |
 
 ### dbsetup examples
 
@@ -166,6 +166,13 @@ Current schema version:001-initial
 Latest schema version:002-leaf
 Schema successfully upgraded to:002-leaf
 ```
+
+{{< alert title="Example: Setup for TLS with MySQL Server" color="primary" >}}JDBC drivers can support additional parameters as part of the JDBC URL string. Which options are supported by a respective JDBC driver depends on the vendor and version.<p><p>In example, for **MySQL** the TLS parameters used by a client like API-Manager or Node-Manager to connect to a server can be enforced to make sure database connections will only be established if the database server offers the required capabilities.<p>
+More details can be found at MySQL Connector/J 5.1 Developer Guide [Connection URL Syntax](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-url-format.html) and [Configuration Properties for Connector/J - Security](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-connp-props-security.html).<p>
+The following example JDBC string illustrates TLS configuration for AWS RDS MySQL to require TLS 1.2, the server certificate must not be checked for a valid trust chain:<p>
+```
+jdbc:mysql://dba3s-np-rds-apimgateway-dev-int-mysql.cpqdyezqyf7p.eu-central-1.rds.amazonaws.com:3306/apimetrics?useSSL=true&requireSSL=true&verifyServerCertificate=false
+```{{< /alert >}}
 
 #### Install a database
 


### PR DESCRIPTION
https://deploy-preview-1784--axway-open-docs.netlify.app/docs/apim_installation/apigtw_install/metrics_db_install/#connect-to-a-database-url

There's no Jira ticket associated. This is to update '**Connect to a database URL**' to add information on how to to secure communication between clients (API-GW and Node-Manager) and a metrics database server (in this case AWS RDS MySQL), since it took me hours to find the solution on how to configure TLS for a Metrics database connection. As this was not mentioned in our docs and within Policy Studio one cannot configure transport security for database connections.

This is to address customer requirement/ feedback to a security audit.

Automatically generated by Netlify CMS