### PR TITLE
Add note to ensure customers add "redaction.xml" correctly

### DIFF
--- a/content/en/docs/apim_administration/apigtw_admin/admin_redactors.md
+++ b/content/en/docs/apim_administration/apigtw_admin/admin_redactors.md
@@ -98,7 +98,7 @@ To enable redaction for an API Gateway instance, perform the following steps:
       <include file="$VINSTDIR/conf/redaction.xml"/>
    </NetService>
    ```
-   **Important:** Ensure the added line is the last in the series, as shown here, or the configuration will not be correct.
+   Ensure the added line is the last in the series, as shown in this example.
 
 7. Restart the API Gateway instance.
 

--- a/content/en/docs/apim_administration/apigtw_admin/admin_redactors.md
+++ b/content/en/docs/apim_administration/apigtw_admin/admin_redactors.md
@@ -98,6 +98,8 @@ To enable redaction for an API Gateway instance, perform the following steps:
       <include file="$VINSTDIR/conf/redaction.xml"/>
    </NetService>
    ```
+   **Important:** Ensure the added line is the last in the series, as shown here, or the configuration will not be correct.
+
 7. Restart the API Gateway instance.
 
 ## Redact HTTP message content


### PR DESCRIPTION
Thank you for your contribution to the Axway-Open-Docs repo.

## Describe the changes

Some customers have been confused about the instructions to add the line enabling redaction "at the end of the file". See for example case 01236111. I've added a note to indicate that it's important to get this right.

## Deploy preview link

https://deploy-preview-1982--axway-open-docs.netlify.app/docs/apim_administration/apigtw_admin/admin_redactors/

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [ ] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._
