### PR TITLE
[RDAPI-24851] [RDAPI-25249] Introduce new flags

### DIFF
--- a/content/en/docs/apim_reference/system_props.md
+++ b/content/en/docs/apim_reference/system_props.md
@@ -431,4 +431,10 @@ Axway-defined Java system properties introduced in the 7.7 20210830 release
 |jdk.xml.entityExpansionLimit | API Gateway |Specifies the XML Schema validation limit for the number of entity expansions. Default value: 64000. |
 |jdk.xml.maxOccurLimit |  API Gateway | Specifies the XML Schema validation limit for the number of content model nodes. Default value: 5000. |
 |com.vordel.dwe.file.Service.includeConfDirectory | API Gateway | Specifies whether or not `conf-dir` and `envSettings.props` are included in the output of the API Gateway File API. |
+|com.vordel.coreapireg.runtime.broker.parameters.allowEmptyDefault | API Manager | Allows empty values for any query parameter data type. Defaults to 'false'. |
+|com.axway.api.runtime.broker.parameters.skipRequiredValidation | API Manager | Allows required parameters validation to be skipped during processing of user requests. Defaults to 'false'. |
+|com.axway.api.runtime.broker.parameters.skipEnumValidation | API Manager | Allows enum parameters validation to be skipped during processing of user requests. Defaults to 'false'. |
+|com.axway.apigw.dbconnection.removeabandoned | API Gateway | Allows removal of abandoned connections if they exceed the abandoned connection timeout. Defaults to 'true'. |
+|com.axway.apigw.dbconnection.removeabandoned.timeoutms | API Gateway | Sets the abandoned connection timeout in milliseconds. Defaults to '300000'. |
+|com.axway.apigw.dbconnection.testonreturn | API Gateway | Allows validation of connections before they are returned to the pool. Defaults to 'true'. |
 | CASSANDRA_PROTOCOL_VERSION | Cassandra  | Specifies which protocol version to set on the Cassandra driver. Allowable values are 3 and 4. Default value is 4. |  

--- a/content/en/docs/apim_reference/system_props.md
+++ b/content/en/docs/apim_reference/system_props.md
@@ -431,7 +431,6 @@ Axway-defined Java system properties introduced in the 7.7 20210830 release
 |jdk.xml.entityExpansionLimit | API Gateway |Specifies the XML Schema validation limit for the number of entity expansions. Default value: 64000. |
 |jdk.xml.maxOccurLimit |  API Gateway | Specifies the XML Schema validation limit for the number of content model nodes. Default value: 5000. |
 |com.vordel.dwe.file.Service.includeConfDirectory | API Gateway | Specifies whether or not `conf-dir` and `envSettings.props` are included in the output of the API Gateway File API. |
-|com.vordel.coreapireg.runtime.broker.parameters.allowEmptyDefault | API Manager | Allows empty values for any query parameter data type. Defaults to 'false'. |
 |com.axway.api.runtime.broker.parameters.skipRequiredValidation | API Manager | Allows required parameters validation to be skipped during processing of user requests. Defaults to 'false'. |
 |com.axway.api.runtime.broker.parameters.skipEnumValidation | API Manager | Allows enum parameters validation to be skipped during processing of user requests. Defaults to 'false'. |
 |com.axway.apigw.dbconnection.removeabandoned | API Gateway | Allows removal of abandoned connections if they exceed the abandoned connection timeout. Defaults to 'true'. |


### PR DESCRIPTION
Thank you for your contribution to the Axway-Open-Docs repo.

## Describe the changes

Introduce the following 3 flags for RDAPI-24851:
com.axway.apigw.dbconnection.removeabandoned
com.axway.apigw.dbconnection.removeabandoned.timeoutms
com.axway.apigw.dbconnection.testonreturn

and the following 2 flags for RDAPI-25249:
com.axway.api.runtime.broker.parameters.skipRequiredValidation
com.axway.api.runtime.broker.parameters.skipEnumValidation

## Deploy preview link

https://deploy-preview-2094--axway-open-docs.netlify.app/docs/apim_reference/system_props/

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [x] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._
