### PR TITLE
RDAPI-26661  adding keyspace restore note

### DIFF
--- a/content/en/docs/cass_admin/cassandra_troubleshooting.md
+++ b/content/en/docs/cass_admin/cassandra_troubleshooting.md
@@ -42,8 +42,6 @@ In the event of a failed migration, you can restore your Cassandra environment t
 
 ### Restored Keyspace not visible in API Manager UI
 
-After restoring a keyspace using the `apigw-backup-tool` the restored KPS data should be visible via the API Manager UI.  However if this is not the case, the Cassandra keyspace name may need to be updated in the Server Settings via Policy Studio.
+After [restoring a keyspace](/docs/cass_admin/cassandra_bur/#restore-the-keyspace-backup) using the `apigw-backup-tool`, the restored KPS data should be visible via the API Manager UI. If this is not the case, the Cassandra keyspace name might need to be updated in the [Server Settings](/docs/apim_administration/apimgr_admin/api_mgmt_config_ps/) via Policy Studio.
 
-By default the keyspace name value is referenced via the variable `x${DOMAINID}_${GROUPID}`. When the API Manager is configured a keyspace will be created matching this naming convention.  If the keyspace being restored has a different name (possibly created with a different Gateway) it's name will need to replace the default Cassandra keyspace value.
-
-
+By default, the keyspace name value is referenced via the `x${DOMAINID}_${GROUPID}` variable. When API Manager is configured a keyspace is created matching this naming convention. If the keyspace being restored has a different name (possibly created with a different API Gateway), you must replace the default Cassandra keyspace value with the new name.

--- a/content/en/docs/cass_admin/cassandra_troubleshooting.md
+++ b/content/en/docs/cass_admin/cassandra_troubleshooting.md
@@ -39,3 +39,11 @@ Run the `nodetool removenode` command to remove the old Cassandra node from the
 ### Restoring to Cassandra 2.2.8/2.2.12
 
 In the event of a failed migration, you can restore your Cassandra environment to its original 2.2.8/2.2.12 state using the backup data. For more information, see [Restore API Management and KPS keyspaces](/docs/cass_admin/cassandra_bur/#restore-api-management-and-kps-keyspaces-manually).
+
+### Restored Keyspace not visible in API Manager UI
+
+After restoring a keyspace using the `apigw-backup-tool` the restored KPS data should be visible via the API Manager UI.  However if this is not the case, the Cassandra keyspace name may need to be updated in the Server Settings via Policy Studio.
+
+By default the keyspace name value is referenced via the variable `x${DOMAINID}_${GROUPID}`. When the API Manager is configured a keyspace will be created matching this naming convention.  If the keyspace being restored has a different name (possibly created with a different Gateway) it's name will need to replace the default Cassandra keyspace value.
+
+


### PR DESCRIPTION
If Cassandra keyspace restored is not visible via API Manager

Thank you for your contribution to the Axway-Open-Docs repo.

## Describe the changes

Enter a brief description of your changes to communicate to the reviewers what you changed and why.

## Deploy preview link

https://deploy-preview-2228--axway-open-docs.netlify.app/docs/cass_admin/cassandra_troubleshooting/#restored-keyspace-not-visible-in-api-manager-ui

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [x] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._
