### PR TITLE
RDAPI-26585 Add section for changes in a list of allowed HTTP methods for API Gateway CORS request

### DIFF
--- a/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
@@ -119,6 +119,11 @@ metadataUrl="./idp_ADFS.xml"
 
 When configuring the global fault handler in API Manager, it is now required to define and select a [fault handler policy](/docs/apim_administration/apimgr_admin/api_mgmt_custom_policies/#add-api-manager-fault-handler-policies).
 
+### List of allowed HTTP methods for API Gateway CORS request
+
+Previsously, API Gateway CORS request returned a list of allowed HTTP methods that included methods of Relative Paths configured to be resolved using Longest Path match where a CORS request path is a sub-path of the Relative Paths.
+Now, a list of allowed HTTP methods includes methods of the longest Relative Paths which are sub-paths of a CORS request path.
+
 ## Deprecated features
 
 As part of our software development life cycle we constantly review our API Management offering. As part of this update, the following capabilities have been deprecated

--- a/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
@@ -139,8 +139,8 @@ When configuring the global fault handler in API Manager, it is now required to 
 
 ### List of allowed HTTP methods for API Gateway CORS request
 
-Previsously, API Gateway CORS request returned a list of allowed HTTP methods that included methods of Relative Paths configured to be resolved using Longest Path match where a CORS request path is a sub-path of the Relative Paths.
-Now, a list of allowed HTTP methods includes methods of the longest Relative Paths which are sub-paths of a CORS request path.
+Previously, API Gateway CORS request returned a list of allowed HTTP methods that included methods of Relative Paths configured to be resolved using Longest Path match where a CORS request path is a sub-path of the Relative Paths.
+Now, the list of allowed HTTP methods includes methods of the longest Relative Paths which are sub-paths of a CORS request path.
 
 ## Deprecated features
 

--- a/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
@@ -137,10 +137,9 @@ During development and testing of API Gateway with Cassandra 3.11.12, a critical
 
 When configuring the global fault handler in API Manager, it is now required to define and select a [fault handler policy](/docs/apim_administration/apimgr_admin/api_mgmt_custom_policies/#add-api-manager-fault-handler-policies).
 
-### List of allowed HTTP methods for API Gateway CORS request
+### New methods added to the list of allowed HTTP methods CORS request
 
-Previously, API Gateway CORS request returned a list of allowed HTTP methods that included methods of Relative Paths configured to be resolved using Longest Path match where a CORS request path is a sub-path of the Relative Paths.
-Now, the list of allowed HTTP methods includes methods of the longest Relative Paths which are sub-paths of a CORS request path.
+[API Gateway CORS](/docs/apim_policydev/apigw_gw_instances/general_cors/) request returned a list of allowed HTTP methods that included methods of relative paths configured to be resolved using Longest Path match, where a CORS request path is a sub-path of the relative paths. Now, the list of allowed HTTP methods includes methods of the longest relative paths, which are sub-paths of a CORS request path.
 
 ## Deprecated features
 

--- a/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
+++ b/content/en/docs/apim_relnotes/20220530_apimgr_relnotes.md
@@ -153,7 +153,7 @@ During development and testing of API Gateway with Cassandra 3.11.12, a critical
 
 When configuring the global fault handler in API Manager, it is now required to define and select a [fault handler policy](/docs/apim_administration/apimgr_admin/api_mgmt_custom_policies/#add-api-manager-fault-handler-policies).
 
-### New methods added to the list of allowed HTTP methods CORS request
+### Improvements to the list of allowed HTTP methods for CORS request
 
 [API Gateway CORS](/docs/apim_policydev/apigw_gw_instances/general_cors/) request returned a list of allowed HTTP methods that included methods of relative paths configured to be resolved using Longest Path match, where a CORS request path is a sub-path of the relative paths. Now, the list of allowed HTTP methods includes methods of the longest relative paths, which are sub-paths of a CORS request path.
 


### PR DESCRIPTION
https://deploy-preview-2327--axway-open-docs.netlify.app/docs/apim_relnotes/20220530_apimgr_relnotes/#list-of-allowed-http-methods-for-api-gateway-cors-request
