### PR TITLE
Migration: use docsy theme as hugo module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ package-lock.json
 
 #Mac
 .DS_Store
+
+#hugo
+.hugo_build.lock

--- a/config.toml
+++ b/config.toml
@@ -3,18 +3,30 @@ title = "Amplify API Management"
 
 enableRobotsTXT = true
 
-# Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
-
-# Will give values to .Lastmod etc.
-enableGitInfo = true
-
 # Language settings
 contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
+
+# Declaration of docsy them as hugo module
+[module]
+  proxy = "direct"
+  # uncomment line below for temporary local development of module
+  # replacements = "github.com/google/docsy -> ../../docsy"
+  [module.hugoVersion]
+    extended = true
+    min = "0.73.0"
+  [[module.imports]]
+    path = "github.com/google/docsy"
+    disable = false
+  [[module.imports]]
+    path = "github.com/google/docsy/dependencies"
+    disable = false
+
+# Will give values to .Lastmod etc.
+enableGitInfo = true
 
 # if removed the site will not build!!
 disableKinds = ["taxonomy", "taxonomyTerm"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Axway/axway-open-docs
+
+go 1.20
+
+require github.com/google/docsy v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
+github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Excerpt from your build script:

https://github.com/Axway/axway-open-docs/blob/a32aa1ba399a5b42f5b52ee3ae6ef5bf7788cf0e/build.sh#L4-L8

Docsy has been updated to work with hugo modules meanwhile. This PR aims to migrate the axway site to the use docsy theme as hugo module. Migration was pretty straightforward and the local site preview looks pretty good already. Two issues I encountered (didn't look further into this):
- background image of start screen is not loaded any more
- main topics `blog` and `community` are missing (couldn't find these folders in the `content`folder).

Everything else looks -on a first glance- fine to me. I hope this PR gets you started to migrate your site to hugo modules.

*Note*: I'm the dev who impemented hugo modules for `docsy` theme. If you run into troble here, I'm willing to help you out.
